### PR TITLE
Handle exceptions for nonexistent branches and repositories in `get`s

### DIFF
--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -13,4 +13,28 @@ def test_get_nonexistent_file(lakefs_client: LakeFSClient, repository: str) -> N
     rpath = f"{repository}/main/hello-i-no-exist1234.txt"
 
     with pytest.raises(FileNotFoundError):
-        fs.get_file(rpath, "out.txt")
+        fs.get(rpath, "out.txt")
+
+
+def test_get_from_nonexistent_repo(lakefs_client: LakeFSClient) -> None:
+    """
+    Tests that a FileNotFoundError and not a lakeFS API exception is raised
+    when attempting to access a nonexistent repository.
+    """
+    fs = LakeFSFileSystem(client=lakefs_client)
+    rpath = "nonexistent-repo/main/a.txt"
+
+    with pytest.raises(FileNotFoundError):
+        fs.get(rpath, "out.txt")
+
+
+def test_get_from_nonexistent_branch(lakefs_client: LakeFSClient, repository: str) -> None:
+    """
+    Tests that a FileNotFoundError and not a lakeFS API exception is raised
+    when attempting to access a nonexistent branch in an existing repository.
+    """
+    fs = LakeFSFileSystem(client=lakefs_client)
+    rpath = f"{repository}/nonexistentbranch/a.txt"
+
+    with pytest.raises(FileNotFoundError):
+        fs.get(rpath, "out.txt")


### PR DESCRIPTION
Previously, using `fs.get()` could fail due to `info()` being called, which in turn runs code without a try-except block on a lakeFS API call (`objects_api.list_objects`).

Solution: Wrap `_ls_internal`'s `objects_api.list_objects` call into a `try-except` block and raise a proper `FileNotFoundError` on failure like in all other places.

Tests did not catch this since a) they only check `get_file` and b) they only checked non-existent files. Coverage is expanded by checking a non-existent repo and a non-existent branch, too.

Part of #4.