### PR TITLE
Add `exist_ok` flag to all resource-creating client helpers

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -53,7 +53,7 @@ def create_branch(
     repository: str
         Repository name.
     name: str
-        Name of the newly created branch.
+        Name of the newly created (or existing) branch.
     source_branch: str
         Name of the source branch the new branch is created from.
     exist_ok: bool
@@ -61,7 +61,7 @@ def create_branch(
 
     Returns
     -------
-    The newly created branch name.
+    The requested branch name.
     """
 
     try:
@@ -85,8 +85,8 @@ def create_repository(
     Important: Due to cleanup issues in the lakeFS backend, creating a repository again after prior
     deletion under the same name and storage namespace will almost certainly not work.
 
-    The exist_ok flag only asserts idempotence in case the repository is not deleted between
-    single `create_repository` calls.
+    The `exist_ok` flag only asserts idempotence in case the repository is not deleted in between
+    `create_repository` calls.
     """
     try:
         repository_creation = RepositoryCreation(name=name, storage_namespace=storage_namespace)

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -20,7 +20,7 @@ from lakefs_sdk.client import LakeFSClient
 from lakefs_sdk.exceptions import ApiException, NotFoundException
 from lakefs_sdk.models import ObjectCopyCreation, ObjectStatsList, StagingMetadata
 
-from lakefs_spec.client_helpers import ensure_branch
+from lakefs_spec.client_helpers import create_branch
 from lakefs_spec.config import LakectlConfig
 from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.transaction import LakeFSTransaction
@@ -492,7 +492,7 @@ class LakeFSFile(AbstractBufferedFile):
         self.buffer: io.BytesIO
         if mode == "wb" and self.fs.create_branch_ok:
             repository, branch, resource = parse(path)
-            ensure_branch(self.fs.client, repository, branch, self.fs.source_branch)
+            create_branch(self.fs.client, repository, branch, self.fs.source_branch)
 
     def _upload_chunk(self, final: bool = False) -> bool:
         """Commits the file on final chunk via single-shot upload, no-op otherwise."""

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -102,11 +102,19 @@ class LakeFSTransaction(Transaction):
 
         self.fs._intrans = False
 
-    def create_branch(self, repository: str, name: str, source_branch: str) -> str:
+    def create_branch(
+        self, repository: str, name: str, source_branch: str, exist_ok: bool = True
+    ) -> str:
         """
         Create a branch with the name `name` in a repository, branching off `source_branch`.
         """
-        op = partial(create_branch, repository=repository, name=name, source_branch=source_branch)
+        op = partial(
+            create_branch,
+            repository=repository,
+            name=name,
+            source_branch=source_branch,
+            exist_ok=exist_ok,
+        )
         self.files.append((op, name))
         return name
 
@@ -136,12 +144,16 @@ class LakeFSTransaction(Transaction):
         self.files.append((op, p))
         return p
 
-    def tag(self, repository: str, ref: str | Placeholder[Commit], tag: str) -> str:
+    def tag(
+        self, repository: str, ref: str | Placeholder[Commit], tag: str, exist_ok: bool = True
+    ) -> str:
         """Create a tag referencing a commit in a repository."""
 
         def tag_op(client: LakeFSClient, **kwargs: Any) -> Ref:
             kwargs = unwrap_placeholders(kwargs)
             return create_tag(client, **kwargs)
 
-        self.files.append((partial(tag_op, repository=repository, ref=ref, tag=tag), tag))
+        self.files.append(
+            (partial(tag_op, repository=repository, ref=ref, tag=tag, exist_ok=exist_ok), tag)
+        )
         return tag

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -106,9 +106,7 @@ class LakeFSTransaction(Transaction):
         """
         Create a branch with the name `name` in a repository, branching off `source_branch`.
         """
-        op = partial(
-            create_branch, repository=repository, name=name, source_branch=source_branch
-        )
+        op = partial(create_branch, repository=repository, name=name, source_branch=source_branch)
         self.files.append((op, name))
         return name
 

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -14,16 +14,23 @@ def test_create_tag(
     random_file = random_file_factory.make()
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
     fs.put(lpath, rpath, precheck=False)
+
     client_helpers.commit(
         client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
     )
 
     tag = f"Change_{uuid.uuid4()}"
     try:
-        client_helpers.create_tag(client=fs.client, repository=repository, ref=temp_branch, tag=tag)
-
-        assert any(commit.id == tag for commit in fs.client.tags_api.list_tags(repository).results)
+        new_tag = client_helpers.create_tag(
+            client=fs.client, repository=repository, ref=temp_branch, tag=tag
+        )
+        assert tag in [commit.id for commit in client_helpers.list_tags(fs.client, repository)]
+        existing_tag = client_helpers.create_tag(
+            client=fs.client, repository=repository, ref=temp_branch, tag=tag
+        )
+        assert new_tag == existing_tag
     finally:
         fs.client.tags_api.delete_tag(repository=repository, tag=tag)
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -121,7 +121,7 @@ def test_transaction_branch(fs: LakeFSFileSystem, repository: str) -> None:
 
     try:
         with fs.transaction as tx:
-            tx.create_branch(repository=repository, branch=branch, source_branch="main")
+            tx.create_branch(repository=repository, name=branch, source_branch="main")
 
         branches = [
             b.id for b in fs.client.branches_api.list_branches(repository=repository).results
@@ -129,7 +129,6 @@ def test_transaction_branch(fs: LakeFSFileSystem, repository: str) -> None:
 
         # existence check for a newly created branch.
         assert branch in branches
-
     finally:
         fs.client.branches_api.delete_branch(
             repository=repository,


### PR DESCRIPTION
This ensures that usage can be made idempotent, which (for us) has the tangible advantage of allowing for faster docs development iterations.

The heuristic to detect a backend "exists" error is only the status code 409 for now, though we could also do a substring search on the reason. This however would incur a JSON parse.

Changes the tag creation API to return a `Ref` model object.

The `ensure_branch` was renamed to `create_branch` on account of the creation option `exist_ok` that was added.

Fixes #153.