### PR TITLE
Change certain aspects of the data science tutorial notebook

### DIFF
--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -9,40 +9,26 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakefs-spec` for data versioning. We will use versioned weather data to train a random forest classifier to predict whether a given day from now is a raining day given the current weather.\n",
+    "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakefs-spec` for data versioning. We will use versioned weather data to train a decision tree classifier to predict whether it is raining tomorrow given the current weather.\n",
     "\n",
     "We will do the following:\n",
     "\n",
     "* Environment setup\n",
     "* LakeFS setup\n",
+    "* Authenticate with the lakeFS client\n",
     "* Data ingestion via transactions\n",
     "* Model training\n",
     "* Updating data and retraining a model\n",
     "* Accessing data versions and reproducing experiments\n",
     "* Using tags for semantic versioning\n",
     "\n",
-    "To execute the code in this tutorial as a Jupyter notebook, download this `.ipynb` file to a convenient location on your machine. You can also clone the whole `lakefs-spec` repository. During the execution of this tutorial, in the same directory, a folder `data` will be created. We will also download a file `.lakectl.yaml` to the current user's home directory.\n",
+    "To execute the code in this tutorial as a Jupyter notebook, download the `.ipynb` file from the `lakefs-spec` repository. \n",
     "\n",
     "This tutorial assumes that you have installed `lakefs-spec` in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
     "\n",
     "## Environment setup\n",
     "\n",
-    "Install the libraries necessary for this notebook on the environment you have just created: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2a1b38a3-dd43-424e-be1a-9c731bdcf4f5",
-   "metadata": {
-    "cell_marker": "\"\"\"",
-    "tags": [
-     "remove_output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "%pip install lakefs-spec numpy pandas scikit-learn"
+    "Install the necessary libraries for this notebook on the environment you have just created: `pip install lakefs-spec numpy pandas scikit-learn`."
    ]
   },
   {
@@ -52,28 +38,17 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "From a terminal, start a Jupyter notebook server if one is not already running, by executing `jupyter notebook`. Double click the notebook to autostart a kernel using the created virtual environment.\n",
-    "\n",
     "## lakeFS Setup\n",
     "\n",
-    "Ensure you have Docker Desktop or a similar runtime available and running.\n",
-    "\n",
-    "Set up LakeFS. You can do this by executing the following `docker run` command (the lakeFS quickstart) in your console:\n",
+    "With Docker Desktop or a similar runtime running set up lakeFS by executing the following `docker run` command (from the [lakeFS quickstart(https://docs.lakefs.io/quickstart/launch.html)]) in your console:\n",
     "\n",
     "`docker run --name lakefs --pull always --rm --publish 8000:8000 treeverse/lakefs:latest run --quickstart`\n",
     "\n",
-    "Open a browser and navigate to the lakeFS instance - by default: http://localhost:8000/. \n",
+    "You find the authentication credentials in the terminal output. The default address for the local lakeFS GUI is http://localhost:8000/. \n",
     "\n",
-    "Authenticate with the following credentials:\n",
+    "## Authenticate with the lakeFS client\n",
     "\n",
-    "    Access Key ID    : AKIAIOSFOLQUICKSTART\n",
-    "    Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
-    "\n",
-    "As an email, you can enter anything, we won't need it in this example.\n",
-    "\n",
-    "Before we instantiate the filesystem connector `LakeFSFilesystem`, we need to configure authentication.\n",
-    "\n",
-    "There are multiple ways to authenticate to lakeFS from Python code - in this tutorial, we choose the convenient YAML file configuration. Execute the code below to download the YAML file including the lakeFS quickstart credentials and server URL to your user directory."
+    "There are multiple ways to authenticate to lakeFS from Python code. In this tutorial, we choose the a YAML file configuration. By executing the cell below you download the default lakeFS quickstart credentials and server URL to your user directory."
    ]
   },
   {
@@ -259,7 +234,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "Next, we save this data as a CSV file into the main branch. When the transaction commit helper is called, the newly put CSV file is committed. You can verify the saving worked in the LakeFS UI in your browser by switching to the commits tab of the `main` branch."
+    "Next, we save this data as a CSV file into the main branch. When the transaction commit helper is called, the newly put CSV file is committed. You can verify the saving worked in the lakeFS UI in your browser by switching to the commits tab of the `main` branch."
    ]
   },
   {
@@ -355,7 +330,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "We now proceed to train a random forest classifier and evaluate it on the test set:"
+    "We now proceed to train a decision tree classifier and evaluate it on the test set:"
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -152,9 +152,7 @@
    },
    "outputs": [],
    "source": [
-    "outfile = tempfile.NamedTemporaryFile(delete=False)\n",
-    "outfile.close() # Close the temporary file to release the file lock on windows and allow us to write data to the file\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)"
+    "outfile, _ = urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\")"
    ]
   },
   {
@@ -191,7 +189,7 @@
     "NEW_BRANCH_NAME = 'transform-raw-data'\n",
     "\n",
     "with fs.transaction as tx:\n",
-    "    fs.put(outfile.name, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')\n",
+    "    fs.put(outfile, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')\n",
     "    tx.commit(repository=REPO_NAME, branch=NEW_BRANCH_NAME, message=\"Add 2010 weather data\")"
    ]
   },
@@ -245,7 +243,7 @@
     "    df = df.dropna()\n",
     "    return df\n",
     "    \n",
-    "df = transform_json_weather_data(outfile.name)\n",
+    "df = transform_json_weather_data(outfile)\n",
     "df.head(5)"
    ]
   },
@@ -268,9 +266,7 @@
    "source": [
     "with fs.transaction as tx:\n",
     "    df.to_csv(f'lakefs://{REPO_NAME}/main/weather_2010.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")\n",
-    "    # delete the temporary local weather file.\n",
-    "    os.remove(outfile.name)"
+    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")"
    ]
   },
   {
@@ -398,16 +394,16 @@
    },
    "outputs": [],
    "source": [
-    "outfile = tempfile.NamedTemporaryFile(delete=False)\n",
-    "outfile.close() # Close to enable write on windows, see above.\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)\n",
+    "outfile, _ = urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\")\n",
     "\n",
-    "new_data = transform_json_weather_data(outfile.name)\n",
+    "new_data = transform_json_weather_data(outfile)\n",
     "\n",
     "with fs.transaction as tx:\n",
     "    new_data.to_csv(f'lakefs://{REPO_NAME}/main/weather_2020.csv')\n",
     "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020 weather data\")\n",
-    "    os.remove(outfile.name)"
+    "\n",
+    "# Remove leftover temporary files from previous `urlretrieve` calls\n",
+    "urllib.request.urlcleanup()"
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -9,25 +9,23 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakeFS-spec` for data versioning. We will use weather data to train a random forest classifier to predict whether a given day from now is a raining day given the current weather.\n",
+    "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakefs-spec` for data versioning. We will use versioned weather data to train a random forest classifier to predict whether a given day from now is a raining day given the current weather.\n",
     "\n",
     "We will do the following:\n",
     "\n",
     "* Environment setup\n",
-    "* lakeFS setup\n",
-    "* Data ingestion\n",
-    "    * Transactions\n",
-    "    * PUT a file\n",
+    "* LakeFS setup\n",
+    "* Data ingestion via transactions\n",
     "* Model training\n",
     "* Updating data and retraining a model\n",
-    "* Accessing data versions and Reproducing Experiments\n",
-    "* Using a tag instead of a commit SHA for semantic versioning\n",
+    "* Accessing data versions and reproducing experiments\n",
+    "* Using tags for semantic versioning\n",
     "\n",
     "To execute the code in this tutorial as a Jupyter notebook, download this `.ipynb` file to a convenient location on your machine. You can also clone the whole `lakefs-spec` repository. During the execution of this tutorial, in the same directory, a folder `data` will be created. We will also download a file `.lakectl.yaml` to the current user's home directory.\n",
     "\n",
     "This tutorial assumes that you have installed `lakefs-spec` in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
     "\n",
-    "# Environment Setup\n",
+    "## Environment setup\n",
     "\n",
     "Install the libraries necessary for this notebook on the environment you have just created: "
    ]
@@ -56,7 +54,7 @@
    "source": [
     "From a terminal, start a Jupyter notebook server if one is not already running, by executing `jupyter notebook`. Double click the notebook to autostart a kernel using the created virtual environment.\n",
     "\n",
-    "# lakeFS Setup\n",
+    "## lakeFS Setup\n",
     "\n",
     "Ensure you have Docker Desktop or a similar runtime available and running.\n",
     "\n",
@@ -85,12 +83,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import urllib.request\n",
     "import os\n",
+    "import tempfile\n",
+    "import urllib.request\n",
     "\n",
-    "destination = os.path.expanduser(\"~/.lakectl.yaml\")\n",
     "urllib.request.urlretrieve(\n",
-    "    \"https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/docs/tutorials/.lakectl.yaml\", destination)"
+    "    \"https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/docs/tutorials/.lakectl.yaml\", os.path.expanduser(\"~/.lakectl.yaml\")\n",
+    ")"
    ]
   },
   {
@@ -120,8 +119,7 @@
    "id": "836f8cd8",
    "metadata": {},
    "source": [
-    "We will create a repository using a helper function provided by `lakefs-spec`. If you created one in the UI, make sure to set the `REPO_NAME` variable in the cell above accordingly. You can re-execute if necessary.\n",
-    "Otherwise, execute the next cell."
+    "We will create a repository using a helper function provided by `lakefs-spec`. If you have already created one in the UI, make sure to set the `REPO_NAME` variable in the cell above accordingly."
    ]
   },
   {
@@ -141,38 +139,11 @@
    "id": "cb9d3502",
    "metadata": {},
    "source": [
-    "# Data Ingestion"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1d37daf2",
-   "metadata": {},
-   "source": [
+    "## Data Ingestion\n",
+    "\n",
     "Now it's time to get some data. We will use the [Open Meteo API](https://open-meteo.com/), where we can pull weather data from an API for free (as long as we are non-commercial) and without an API-token.\n",
     "\n",
-    "First, create the folder `data` inside a directory when your notebook is located:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c20f56ba",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.makedirs(\"data\", exist_ok=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18f35215",
-   "metadata": {
-    "cell_marker": "\"\"\"",
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "Then, for the purpose of training, get the full 2010 weather data from Munich:"
+    "For training our toy model, we download the full weather data of Munich for the year 2010:"
    ]
   },
   {
@@ -184,8 +155,8 @@
    },
    "outputs": [],
    "source": [
-    "destination = \"data/weather-2010.json\"\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)"
+    "outfile = tempfile.NamedTemporaryFile()\n",
+    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)"
    ]
   },
   {
@@ -195,42 +166,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# PUT a file\n",
-    "\n",
-    "The data is in JSON format. Therefore, we need to wrangle the data a bit to make it usable. But first we will save it into our lakeFS instance.\n",
-    "\n",
-    "lakeFS works similar to `git` as a versioning system. You can create *commits* that contain specific changes to the data. You can also work with *branches* to fork your own copy of the data such that you don't interfere with your colleagues. Every commit (on any branch) is identified by a commit SHA. This SHA can be used to programmatically interact with specific states of your data and enables logging of the specific data versions used to create a certain model. We will cover all of this in this demo.\n",
-    "\n",
-    "For now, we will `put` the file we have on a new branch, `transform-raw-data`, specifically created for our data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b94db09",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "from lakefs_spec import LakeFSFileSystem\n",
-    "LakeFSFileSystem.clear_instance_cache()\n",
-    "\n",
-    "NEW_BRANCH_NAME = 'transform-raw-data'\n",
-    "\n",
-    "fs = LakeFSFileSystem()\n",
-    "fs.put(destination, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1f86a01a",
-   "metadata": {
-    "cell_marker": "\"\"\"",
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "Going to the LakeFS UI in your browser, you can change the branch view to `transform-raw-data` and see the saved file. However, the change is not yet committed. While you can do that manually via the uncommitted changes tab in the UI, we will commit the file in a different way."
+    "The data is in JSON format. Therefore, we need to wrangle the data a bit to make it usable. But first we will save it into our lakeFS instance."
    ]
   },
   {
@@ -238,15 +174,11 @@
    "id": "8bd285eb",
    "metadata": {},
    "source": [
-    "## Transactions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "729cadd9",
-   "metadata": {},
-   "source": [
-    "To easily carry out versioning operations while uploading files, you can use a *transaction*. A transaction is a context manager that keeps track of all files that were uploaded in its scope, as well as all versioning operations happening in between file uploads. All operations are deferred to the end of the transaction, and are executed sequentially on completion.\n",
+    "## Upload a file using transactions\n",
+    "\n",
+    "lakeFS works similar to `git` as a versioning system. You can create *commits* that contain specific changes to the data. You can also work with *branches* to create your own isolated view of the data independently of your colleagues. Every commit (on any branch) is identified by a commit SHA. This SHA can be used to programmatically interact with specific states of your data and enables logging of the specific data versions used to create a certain model.\n",
+    "\n",
+    "To easily carry out versioning operations while uploading files, you can use a *transaction*. A transaction is a context manager that keeps track of all files that were uploaded in its scope, as well as all versioning operations happening between file uploads. All operations are deferred to the end of the transaction, and are executed sequentially on completion.\n",
     "\n",
     "To create a commit after a file upload, you can run the following transaction:"
    ]
@@ -258,8 +190,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "NEW_BRANCH_NAME = 'transform-raw-data'\n",
+    "\n",
     "with fs.transaction as tx:\n",
-    "    fs.put(destination, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json', precheck=True, autocommit=False)\n",
+    "    fs.put(outfile.name, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')\n",
     "    tx.commit(repository=REPO_NAME, branch=NEW_BRANCH_NAME, message=\"Add 2010 weather data\")"
    ]
   },
@@ -270,9 +204,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "This transaction, if successful, will create a commit. Since we already uploaded the file, lakeFS will skip the upload as the checksums of the local and remote file match.\n",
-    "\n",
-    "If we want to execute the upload even for an unchanged file, we can do so by passing `precheck=False` to the `fs.put()` operation."
+    "You can inspect this commit by selecting the `transform-raw-data` branch, and navigating to the **Commits** tab."
    ]
   },
   {
@@ -282,12 +214,13 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Data Transformation\n",
+    "## Data Transformation\n",
+    "\n",
     "Now let's transform the data for our use case. We put the transformation into a function to be able to reuse it later.\n",
     "\n",
-    "In this notebook, we follow a simple toy example to predict whether it is raining at the same time tomorrow given weather data from right now.\n",
+    "In this notebook, we use a simple toy model to predict whether it is raining at the same time tomorrow given weather data from right now.\n",
     "\n",
-    "We will skip a lot of possible feature engineering etc. in order to focus on the application of lakeFS and the `LakeFSFileSystem`."
+    "We will skip a lot of possible feature engineering and other data science aspects in order to focus more on the application of the `LakeFSFileSystem`."
    ]
   },
   {
@@ -298,22 +231,23 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "\n",
     "import pandas as pd\n",
     "\n",
-    "\n",
     "def transform_json_weather_data(filepath):\n",
-    "    with open(filepath,\"r\") as f:\n",
-    "        data = json.load(f)\n",
+    "    if hasattr(filepath, \"close\") and hasattr(filepath, \"tell\"):\n",
+    "        data = json.load(filepath)\n",
+    "    else:\n",
+    "        with open(filepath,\"r\") as f:\n",
+    "            data = json.load(f)\n",
     "\n",
     "    df = pd.DataFrame.from_dict(data[\"hourly\"])\n",
     "    df.time = pd.to_datetime(df.time)\n",
     "    df['is_raining'] = df.rain > 0\n",
-    "    df['is_raining_in_1_day'] = df.is_raining.shift(24)\n",
+    "    df['is_raining_in_1_day'] = df.is_raining.shift(24).astype(bool)\n",
     "    df = df.dropna()\n",
     "    return df\n",
     "    \n",
-    "df = transform_json_weather_data('data/weather-2010.json')\n",
+    "df = transform_json_weather_data(outfile)\n",
     "df.head(5)"
    ]
   },
@@ -336,7 +270,9 @@
    "source": [
     "with fs.transaction as tx:\n",
     "    df.to_csv(f'lakefs://{REPO_NAME}/main/weather_2010.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")"
+    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")\n",
+    "    # delete the temporary local weather file.\n",
+    "    outfile.close()"
    ]
   },
   {
@@ -346,7 +282,8 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Model Training\n",
+    "## Training the initial weather model\n",
+    "\n",
     "First we will do a train-test split:"
    ]
   },
@@ -391,37 +328,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a79efb76",
-   "metadata": {
-    "cell_marker": "\"\"\""
-   },
-   "source": [
-    "Implicit branch creation is a convenient way to create new branches programmatically. However, one drawback is that typos in your code might result in new accidental branch creations. If you want to avoid this implicit behavior and raise errors instead, you can disable implicit branch creation by setting `fs.create_branch_ok=False`.\n",
-    "\n",
-    "We can now read train and test files directly from the remote LakeFS instance. (You can verify that neither the train nor the test file are saved in the `/data` directory)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7b3f6367",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv', index_col=0)\n",
-    "test = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/test_weather.csv', index_col=0)\n",
-    "\n",
-    "train.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "58c9c4dc",
    "metadata": {
     "cell_marker": "\"\"\""
    },
    "source": [
-    "Let's check the shape of train and test data. Later on we will train to get back to this data version and reproduce the results of the experiment."
+    "Let's check the shape of train and test data. Later on, we will get back to this data version and reproduce the results of the experiment."
    ]
   },
   {
@@ -457,13 +369,13 @@
     "dependent_variable = 'is_raining_in_1_day'\n",
     "\n",
     "model = DecisionTreeClassifier(random_state=7)\n",
+    "\n",
     "x_train, y_train = train.drop(dependent_variable, axis=1), train[dependent_variable].astype(bool)\n",
     "x_test, y_test = test.drop(dependent_variable, axis=1), test[dependent_variable].astype(bool)\n",
     "\n",
     "model.fit(x_train, y_train)\n",
     "\n",
     "test_acc = model.score(x_test, y_test)\n",
-    "\n",
     "print(f\"Test accuracy: {test_acc:.2%}\")"
    ]
   },
@@ -474,7 +386,8 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Updating Data and Model\n",
+    "## Updating data and retraining the model\n",
+    "\n",
     "Until now, we only have used data from 2010. Let's download additional 2020 data, transform it, and save it to LakeFS."
    ]
   },
@@ -487,24 +400,15 @@
    },
    "outputs": [],
    "source": [
-    "destination = \"data/weather-2020.json\"\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)\n",
+    "outfile = tempfile.NamedTemporaryFile()\n",
+    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)\n",
     "\n",
-    "new_data = transform_json_weather_data('data/weather-2020.json')\n",
+    "new_data = transform_json_weather_data(outfile)\n",
     "\n",
     "with fs.transaction as tx:\n",
     "    new_data.to_csv(f'lakefs://{REPO_NAME}/main/weather_2020.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020 weather data\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11242a6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_data = new_data.drop('time', axis=1)"
+    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020 weather data\")\n",
+    "    outfile.close()"
    ]
   },
   {
@@ -514,7 +418,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "Let's concatenate the old data and the new data, create a new train-test split, and overwrite the files on lakeFS:"
+    "Let's concatenate the old data and the new data, create a new train-test split, and push the updated files to lakeFS:"
    ]
   },
   {
@@ -524,12 +428,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_train = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv', index_col=0)\n",
-    "df_test = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/test_weather.csv', index_col=0)\n",
-    "\n",
-    "full_data = pd.concat([new_data, df_train, df_test])\n",
+    "new_data = new_data.drop('time', axis=1)\n",
+    "full_data = pd.concat([new_data, train, test])\n",
     "\n",
     "train_df, test_df = sklearn.model_selection.train_test_split(full_data, random_state=7)\n",
+    "\n",
+    "print(f'Updated train data shape: {train_df.shape}')\n",
+    "print(f'Updated test data shape: {test_df.shape}')\n",
     "\n",
     "with fs.transaction as tx:\n",
     "    train_df.to_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv')\n",
@@ -539,38 +444,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1b84823",
-   "metadata": {
-    "cell_marker": "\"\"\"",
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "We may now read the updated data directly from lakeFS and check their shape to insure that initial files `train_weather.csv` and `test_weather.csv` have been overwritten successfully (number of rows should be significantly higher as 2020 data were added):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d92a3639",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "train = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv', index_col=0)\n",
-    "test = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/test_weather.csv', index_col=0)\n",
-    "\n",
-    "print(f'Updated train data shape: {train.shape}')\n",
-    "print(f'Updated test data shape: {test.shape}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "b862924e",
    "metadata": {
     "cell_marker": "\"\"\""
    },
    "source": [
-    "Now we may train the model based on the new train data and validate based on the new test data:"
+    "Now, we train the model on the new data and validate on the new test data."
    ]
   },
   {
@@ -580,8 +459,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_train, y_train = train.drop(dependent_variable, axis=1), train[dependent_variable].astype(bool)\n",
-    "x_test, y_test = test.drop(dependent_variable, axis=1), test[dependent_variable].astype(bool)\n",
+    "x_train, y_train = train_df.drop(dependent_variable, axis=1), train_df[dependent_variable].astype(bool)\n",
+    "x_test, y_test = test_df.drop(dependent_variable, axis=1), test_df[dependent_variable].astype(bool)\n",
     "\n",
     "model.fit(x_train, y_train)\n",
     "\n",
@@ -597,13 +476,13 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Accessing Data Version and Reproducing Experiment\n",
+    "## Accessing data versions through commits and reproducing experiments\n",
     "\n",
-    "Let's assume we need to go to our initial data and reproduce the first experiment (the model trained on the 2010 data with its initial accuracy). This might be tricky as we have overwritten initial train and test data on lakeFS.\n",
+    "If we need to go to our initial data and reproduce the first experiment (the model trained on the 2010 data with its initial accuracy), we can go back in the commit history of the `training` branch and select the appropriate commit data snapshot. Since we have created multiple commits on the same branch already, we will address different data versions by their commit SHAs. \n",
     "\n",
-    "To enable data versioning we should save the `ref` of the specific datasets. `ref` can be a branch we are pulling a file from LakeFS. `ref` can be also a commit id - then you can access different data versions within the same branch and not only the version from the latest commit. Therefore, we will use explicit versioning and get the actual commit SHA. We have multiple ways to do this. Manually, we could go into the lakeFS UI, select the training branch, and navigate to the \"Commits\" tab. There, we could see the second-latest commit, titled `Add train-test split of 2010 weather data`, and copy its ID.\n",
+    "To obtain the actual commit SHA from a branch, we have multiple options. Manually, we could go into the lakeFS UI, select the training branch, and navigate to the **Commits** tab. There, we take the parent of the previous commit, titled `Add train-test split of 2010 weather data`, and copy its revision SHA (also called `ID`).\n",
     "\n",
-    "However, we want to automate as much as possible and therefore use a helper function. You find pre-written helper functions in the `lakefs_spec.client_helpers` module:"
+    "In code, we can use a versioning helper called `rev_parse` to obtain commit SHAs for different revisions on the `training` branch."
    ]
   },
   {
@@ -615,7 +494,7 @@
    "source": [
     "from lakefs_spec.client_helpers import rev_parse\n",
     "\n",
-    "# parent is a relative number of a commit when 0 is the latest\n",
+    "# parent is the parent number of a commit relative to HEAD (the latest commit, for which parent = 0).\n",
     "previous_commit = rev_parse(fs.client, REPO_NAME, TRAINING_BRANCH, parent=1)\n",
     "fixed_commit_id = previous_commit.id\n",
     "print(fixed_commit_id)"
@@ -623,18 +502,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02e2558b",
-   "metadata": {},
-   "source": [
-    "With our transaction setup, both `DataFrame.to_csv()` operations are kept in a single commit. To get other commits with the `rev_parse` function, you can change the `repository` and `branch` parameters. To go back in the chosen branch's commit history, you can increase the `parent` parameter. In our case the initial data was commited two commits ago - we count the latest commit on a branch as 0, thus `parent = 1`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "9adf24fc",
    "metadata": {},
    "source": [
-    "Let's check whether we manage to get the initial train and test data with this commit SHA, comparing the shape to the initial data shape:"
+    "Let's check whether we managed to get the initial train and test data with this commit SHA, checking equality to the initial data:"
    ]
   },
   {
@@ -644,11 +515,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train = pd.read_csv(f\"lakefs://{REPO_NAME}/{fixed_commit_id}/train_weather.csv\", index_col=0)\n",
-    "test = pd.read_csv(f\"lakefs://{REPO_NAME}/{fixed_commit_id}/test_weather.csv\", index_col=0)\n",
+    "orig_train = pd.read_csv(f\"lakefs://{REPO_NAME}/{fixed_commit_id}/train_weather.csv\", index_col=0)\n",
+    "orig_test = pd.read_csv(f\"lakefs://{REPO_NAME}/{fixed_commit_id}/test_weather.csv\", index_col=0)\n",
     "\n",
-    "print(f'train data shape: {train.shape}')\n",
-    "print(f'test data shape: {test.shape}')"
+    "print(f'Is the pulled training data equal to the local training data? {train.equals(orig_train)}')\n",
+    "print(f'Is the pulled test data equal to the local test data? {test.equals(orig_test)}')"
    ]
   },
   {
@@ -659,7 +530,7 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "Let's train and validate the model based on re-fetched data and see whether we manage to reproduce the initial accuracy ratio:  "
+    "Let's train and validate the model again based on the redownloaded data and see if we manage to reproduce the initial accuracy.  "
    ]
   },
   {
@@ -686,8 +557,9 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Using a tag instead of a commit SHA for semantic versioning\n",
-    "The above method for data versioning works great when you have experiment tracking tools to store and retrieve the commit SHA in automated pipelines. But it is hard to remember and tedious to retrieve in manual prototyping. We can make selected versions of the dataset more accessible with semantic versioning. We attach a human-interpretable tag that points to a specific commit SHA.\n",
+    "## Using tags instead of commit SHAs for semantic versioning\n",
+    "\n",
+    "The above method for data versioning works great when you have experiment tracking tools to store and retrieve the commit SHA in automated pipelines. But it can be tedious to retrieve in manual prototyping. We can make selected versions of the dataset more accessible with semantic versioning by attaching a human-interpretable tag to a specific commit SHA.\n",
     "\n",
     "Creating a tag is easiest when done inside a transaction, just like the files we already uploaded. To do this, simply call `tx.tag` on the transaction and supply the repository name, the commit SHA to tag, and the intended tag name."
    ]
@@ -723,9 +595,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_from_branch_head = pd.read_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv', index_col=0)\n",
-    "train_from_commit_sha = pd.read_csv(f'lakefs://{REPO_NAME}/{fixed_commit_id}/train_weather.csv', index_col=0)\n",
-    "train_from_semantic_tag = pd.read_csv(f'lakefs://{REPO_NAME}/{tag}/train_weather.csv', index_col=0)"
+    "train_from_commit = pd.read_csv(f'lakefs://{REPO_NAME}/{fixed_commit_id}/train_weather.csv', index_col=0)\n",
+    "train_from_tag = pd.read_csv(f'lakefs://{REPO_NAME}/{tag}/train_weather.csv', index_col=0)"
    ]
   },
   {
@@ -735,7 +606,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "We can verify this by looking at the lengths of the `DataFrame`s. We see that the `train_from_commit_sha` and `train_from_semantic_tag` are equal. "
+    "We can verify this by comparing the `DataFrame`s. We see that the `train_from_commit` and `train_from_tag` are equal."
    ]
   },
   {
@@ -745,9 +616,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(len(train_from_branch_head))\n",
-    "print(len(train_from_commit_sha))\n",
-    "print(len(train_from_semantic_tag))"
+    "print(f\"Is the data tagged {tag!r} equal to the data in commit {fixed_commit_id[:8]}? {train_from_commit.equals(train_from_tag)}\")"
    ]
   }
  ],

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -28,7 +28,48 @@
     "\n",
     "## Environment setup\n",
     "\n",
-    "Install the necessary libraries for this notebook on the environment you have just created: `pip install lakefs-spec numpy pandas scikit-learn`."
+    "Install the necessary libraries for this notebook on the environment you have just created: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: numpy in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (1.26.2)\n",
+      "Requirement already satisfied: pandas in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (2.1.3)\n",
+      "Requirement already satisfied: scikit-learn in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (1.3.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2023.3.post1)\n",
+      "Requirement already satisfied: tzdata>=2022.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2023.3)\n",
+      "Requirement already satisfied: scipy>=1.5.0 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (1.11.4)\n",
+      "Requirement already satisfied: joblib>=1.1.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (1.3.2)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (3.2.0)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install numpy pandas scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also install the appropriate lakeFS-spec version. That is either the latest release from PyPI via `pip install lakefs-spec`, or the development version from GitHub via `pip install git+https://github.com/aai-institute/lakefs-spec.git`."
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -50,7 +50,7 @@
    "id": "62b5fbb9",
    "metadata": {},
    "source": [
-    "Also install the appropriate lakeFS-spec version. That is either the latest release from PyPI via `pip install lakefs-spec`, or the development version from GitHub via `pip install git+https://github.com/aai-institute/lakefs-spec.git`."
+    "Also install an appropriate lakeFS-spec version, which can be either the latest release from PyPI via `pip install --upgrade lakefs-spec`, or the development version from GitHub via `pip install git+https://github.com/aai-institute/lakefs-spec.git`."
    ]
   },
   {
@@ -62,7 +62,7 @@
    "source": [
     "## lakeFS Setup\n",
     "\n",
-    "With Docker Desktop or a similar runtime running set up lakeFS by executing the following `docker run` command (from the [lakeFS quickstart(https://docs.lakefs.io/quickstart/launch.html)]) in your console:\n",
+    "With Docker Desktop or a similar runtime running set up lakeFS by executing the following `docker run` command (from the [lakeFS quickstart](https://docs.lakefs.io/quickstart/launch.html)) in your console:\n",
     "\n",
     "`docker run --name lakefs --pull always --rm --publish 8000:8000 treeverse/lakefs:latest run --quickstart`\n",
     "\n",
@@ -70,7 +70,7 @@
     "\n",
     "## Authenticating with the lakeFS server\n",
     "\n",
-    "There are multiple ways to authenticate to lakeFS from Python code. In this tutorial, we choose the a YAML file configuration. By executing the cell below you download the default lakeFS quickstart credentials and server URL to your user directory."
+    "There are multiple ways to authenticate with lakeFS from Python code. In this tutorial, we choose the YAML file configuration. By executing the cell below, you will download a YAML file containing the default lakeFS quickstart credentials and server URL to your user directory."
    ]
   },
   {
@@ -94,7 +94,7 @@
    "id": "f4127bf1",
    "metadata": {},
    "source": [
-    "Now we can instantiate the `LakeFSFileSystem` and it will use the credentials we just downloaded for authentication. Alternatively, we could have passed the credentials in the code. It is important, that the credentials are available at the time of filesystem instantiation. "
+    "We can now instantiate the `LakeFSFileSystem` with the credentials we just downloaded. Alternatively, we could have passed the credentials directly in the code. It is important that the credentials are available at the time of filesystem instantiation. "
    ]
   },
   {
@@ -116,7 +116,7 @@
    "id": "836f8cd8",
    "metadata": {},
    "source": [
-    "We will create a repository using a helper function provided by lakeFS-spec. If you have already created one in the UI, make sure to set the `REPO_NAME` variable in the cell above accordingly."
+    "We will create a repository using a helper function provided by lakeFS-spec. If you have already created one in the UI, make sure to set the `REPO_NAME` variable accordingly in the cell directly above."
    ]
   },
   {
@@ -164,7 +164,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "The data is in JSON format. Therefore, we need to wrangle the data a bit to make it usable. But first we will save it into our lakeFS instance."
+    "The data is in JSON format. Therefore, we need to wrangle the data a bit to make it usable. But first, we will upload it to our lakeFS instance."
    ]
   },
   {
@@ -176,7 +176,7 @@
     "\n",
     "lakeFS works similar to `git` as a versioning system. You can create *commits* that contain specific changes to the data. You can also work with *branches* to create your own isolated view of the data independently of your colleagues. Every commit (on any branch) is identified by a commit SHA. This SHA can be used to programmatically interact with specific states of your data and enables logging of the specific data versions used to create a certain model.\n",
     "\n",
-    "To easily carry out versioning operations while uploading files, you can use a *transaction*. A transaction is a context manager that keeps track of all files that were uploaded in its scope, as well as all versioning operations happening between file uploads. All operations are deferred to the end of the transaction, and are executed sequentially on completion.\n",
+    "To easily carry out versioning operations while uploading files, you can use **transactions**. A transaction is a context manager that keeps track of all files that were uploaded in its scope, as well as all versioning operations happening between file uploads. All operations are deferred to the end of the transaction, and are executed sequentially on completion.\n",
     "\n",
     "To create a commit after a file upload, you can run the following transaction:"
    ]
@@ -644,7 +644,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -155,7 +155,8 @@
    },
    "outputs": [],
    "source": [
-    "outfile = tempfile.NamedTemporaryFile()\n",
+    "outfile = tempfile.NamedTemporaryFile(delete=False)\n",
+    "outfile.close() # Close the temporary file to release the file lock on windows and allow us to write data to the file\n",
     "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)"
    ]
   },
@@ -247,7 +248,7 @@
     "    df = df.dropna()\n",
     "    return df\n",
     "    \n",
-    "df = transform_json_weather_data(outfile)\n",
+    "df = transform_json_weather_data(outfile.name)\n",
     "df.head(5)"
    ]
   },
@@ -272,7 +273,7 @@
     "    df.to_csv(f'lakefs://{REPO_NAME}/main/weather_2010.csv')\n",
     "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")\n",
     "    # delete the temporary local weather file.\n",
-    "    outfile.close()"
+    "    os.remove(outfile.name)"
    ]
   },
   {
@@ -400,15 +401,16 @@
    },
    "outputs": [],
    "source": [
-    "outfile = tempfile.NamedTemporaryFile()\n",
+    "outfile = tempfile.NamedTemporaryFile(delete=False)\n",
+    "outfile.close() # Close to enable write on windows, see above.\n",
     "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", outfile.name)\n",
     "\n",
-    "new_data = transform_json_weather_data(outfile)\n",
+    "new_data = transform_json_weather_data(outfile.name)\n",
     "\n",
     "with fs.transaction as tx:\n",
     "    new_data.to_csv(f'lakefs://{REPO_NAME}/main/weather_2020.csv')\n",
     "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020 weather data\")\n",
-    "    outfile.close()"
+    "    os.remove(outfile.name)"
    ]
   },
   {
@@ -645,7 +647,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "* Environment setup\n",
     "* LakeFS setup\n",
-    "* Authenticate with the lakeFS client\n",
+    "* Authenticating with the lakeFS server\n",
     "* Data ingestion via transactions\n",
     "* Model training\n",
     "* Updating data and retraining a model\n",
@@ -33,40 +33,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "id": "1df0b372",
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: numpy in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (1.26.2)\n",
-      "Requirement already satisfied: pandas in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (2.1.3)\n",
-      "Requirement already satisfied: scikit-learn in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (1.3.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2.8.2)\n",
-      "Requirement already satisfied: pytz>=2020.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2023.3.post1)\n",
-      "Requirement already satisfied: tzdata>=2022.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from pandas) (2023.3)\n",
-      "Requirement already satisfied: scipy>=1.5.0 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (1.11.4)\n",
-      "Requirement already satisfied: joblib>=1.1.1 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (1.3.2)\n",
-      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from scikit-learn) (3.2.0)\n",
-      "Requirement already satisfied: six>=1.5 in /Users/maxmynter/Desktop/appliedAI/lakefs/lakefs-spec/.venv/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install numpy pandas scikit-learn"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "62b5fbb9",
    "metadata": {},
    "source": [
     "Also install the appropriate lakeFS-spec version. That is either the latest release from PyPI via `pip install lakefs-spec`, or the development version from GitHub via `pip install git+https://github.com/aai-institute/lakefs-spec.git`."
@@ -87,7 +68,7 @@
     "\n",
     "You find the authentication credentials in the terminal output. The default address for the local lakeFS GUI is http://localhost:8000/. \n",
     "\n",
-    "## Authenticate with the lakeFS client\n",
+    "## Authenticating with the lakeFS server\n",
     "\n",
     "There are multiple ways to authenticate to lakeFS from Python code. In this tutorial, we choose the a YAML file configuration. By executing the cell below you download the default lakeFS quickstart credentials and server URL to your user directory."
    ]

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakefs-spec` for data versioning. We will use versioned weather data to train a decision tree classifier to predict whether it is raining tomorrow given the current weather.\n",
+    "In this notebook, we will complete a small end-to-end data science tutorial that employs lakeFS-spec for data versioning. We will use versioned weather data to train a decision tree classifier to predict whether it is raining tomorrow given the current weather.\n",
     "\n",
     "We will do the following:\n",
     "\n",
@@ -22,9 +22,9 @@
     "* Accessing data versions and reproducing experiments\n",
     "* Using tags for semantic versioning\n",
     "\n",
-    "To execute the code in this tutorial as a Jupyter notebook, download the `.ipynb` file from the `lakefs-spec` repository. \n",
+    "To execute the code in this tutorial as a Jupyter notebook, download the `.ipynb` file from the lakeFS-spec repository. \n",
     "\n",
-    "This tutorial assumes that you have installed `lakefs-spec` in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
+    "This tutorial assumes that you have installed lakeFS-spec in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
     "\n",
     "## Environment setup\n",
     "\n",
@@ -94,7 +94,7 @@
    "id": "836f8cd8",
    "metadata": {},
    "source": [
-    "We will create a repository using a helper function provided by `lakefs-spec`. If you have already created one in the UI, make sure to set the `REPO_NAME` variable in the cell above accordingly."
+    "We will create a repository using a helper function provided by lakeFS-spec. If you have already created one in the UI, make sure to set the `REPO_NAME` variable in the cell above accordingly."
    ]
   },
   {


### PR DESCRIPTION
Improves a few aspects of the tutorial:

* The weather API data is now saved to a temporary file, no more directories are created. The tempfiles are closed immediately after their last uses in the upload transactions.
* The separate `put` operation section was cut, because the showcase of a commit abort is unnecessary. Instead, the focus is shifted to the transactional upload of the data frames.
* Instead of shape comparisons, `pandas.DataFrame.equal` is used to establish equality of local vs. remote downloaded data. This actually caught a dtype mismatch between two datasets.
* Through style changes and regroups, a number of text passages were slimmed down or cut entirely.