### PR TITLE
Change `fs.info()` logic to recognize non-slash-terminated directories

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -251,36 +251,44 @@ class LakeFSFileSystem(AbstractFileSystem):
     def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
         path = self._strip_protocol(path)
 
-        # input path is a directory name
-        if path.endswith("/"):
-            out = self.ls(path, detail=True, **kwargs)
-            if not out:
-                raise FileNotFoundError(path)
+        repository, ref, resource = parse(path)
+        # first, try with `stat_object` in case of a file.
+        # the condition below checks edge cases of resources that cannot be files.
+        if resource and not resource.endswith("/"):
+            try:
+                # the set of keyword arguments allowed in `list_objects` is a
+                # superset of the keyword arguments for `stat_object`.
+                # Ensure that only admissible keyword arguments are actually
+                # passed to `stat_object`.
+                stat_keywords = ["presign", "user_metadata"]
+                stat_kwargs = {k: v for k, v in kwargs.items() if k in stat_keywords}
 
-            resource = path.split("/", maxsplit=2)[-1]
-            statobj = {
-                "name": resource,
-                "size": sum(o.get("size", 0) for o in out),
-                "type": "directory",
-            }
-        # input path is a file name
-        else:
-            with self.wrapped_api_call():
-                repository, ref, resource = parse(path)
                 res = self.client.objects_api.stat_object(
-                    repository=repository, ref=ref, path=resource, **kwargs
+                    repository=repository, ref=ref, path=resource, **stat_kwargs
                 )
+                return {
+                    "checksum": res.checksum,
+                    "content-type": res.content_type,
+                    "mtime": res.mtime,
+                    "name": f"{repository}/{ref}/{res.path}",
+                    "size": res.size_bytes,
+                    "type": "file",
+                }
+            except NotFoundException:
+                # fall through, retry with `ls` if it's a directory.
+                pass
+            except ApiException as e:
+                raise translate_lakefs_error(e)
 
-            statobj = {
-                "checksum": res.checksum,
-                "content-type": res.content_type,
-                "mtime": res.mtime,
-                "name": res.path,
-                "size": res.size_bytes,
-                "type": "file",
-            }
+        out = self.ls(path, detail=True, **kwargs)
+        if not out:
+            raise FileNotFoundError(path)
 
-        return statobj
+        return {
+            "name": path.rstrip("/"),
+            "size": sum(o.get("size", 0) for o in out),
+            "type": "directory",
+        }
 
     def ls(self, path: str, detail: bool = True, **kwargs: Any) -> list:
         path = self._strip_protocol(path)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -21,3 +21,17 @@ def test_info_on_nonexistent_directory(fs: LakeFSFileSystem, repository: str) ->
 
     with pytest.raises(FileNotFoundError):
         fs.info(resource)
+
+
+def test_info_on_directory_no_trailing_slash(fs: LakeFSFileSystem, repository: str) -> None:
+    """
+    Regression test to check that calling `fs.info()` on existing non-slash-terminated
+    directories yields the same results as if terminated with a slash.
+    """
+    resource = f"{repository}/main/data/"
+    res = fs.info(resource)
+
+    assert res["type"] == "directory"
+
+    non_slash_resource = resource.rstrip("/")
+    assert fs.info(non_slash_resource) == res

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -75,7 +75,7 @@ def test_ls_stale_cache_entry(
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/data/{random_file.name}"
 
-    fs.put_file(lpath, rpath)
+    fs.put_file(lpath, rpath, precheck=False)
 
     res = fs.ls(rpath)
     assert counter.count("objects_api.list_objects") == 2


### PR DESCRIPTION
Previously, our heuristic for calling `objects_api.stat_object` was the resource terminating in a slash.

However, we put this into an `if-else` branch, meaning that `objects_api.list_objects` would never be called on a directory resource that was not slash-terminated. This leads to erroneous "not found" errors on existing directories.

The heuristic now changes to the strategy "call `stat_object` first, return if successful, otherwise call `list_objects`". This ensures that on an unsuccessful `stat_objects` call on a directory, the correct `list_objects` call follows directly afterwards.

Also adds a regression test for the behavior.

------

Repro on main (currently results in "404 not found" as mentioned above, requires a repo "lakefs-spec-tests" with sample data):

```python
from lakefs_spec import LakeFSFileSystem

def main():
    """
    Regression test to check that calling `fs.info()` on existing non-slash-terminated
    directories yields the same results as if terminated with a slash.
    """
    fs = LakeFSFileSystem()
    resource = "lakefs-spec-tests/main/data/"
    res = fs.info(resource)

    assert res["type"] == "directory"

    non_slash_resource = resource.rstrip("/")
    assert fs.info(non_slash_resource) == res


if __name__ == "__main__":
    main()
```

I think this is worth it since we all hate websites that behave differently on trailing-slash vs. no trailing slash requests.