### PR TITLE
Improvements to `ls` implementation

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -286,7 +286,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         repository, ref, prefix = parse(path)
 
         try:
-            cache_entry: list[Any] | None = self._ls_from_cache(prefix)
+            cache_entry: list[Any] | None = self._ls_from_cache(path)
         except FileNotFoundError:
             # we patch files missing from an ls call in the cache entry below,
             # so this should not be an error.
@@ -313,7 +313,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                             "checksum": obj.checksum,
                             "content-type": obj.content_type,
                             "mtime": obj.mtime,
-                            "name": obj.path,
+                            "name": f"{repository}/{ref}/{obj.path}",
                             "size": obj.size_bytes,
                             "type": "file",
                         }

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -285,17 +285,25 @@ class LakeFSFileSystem(AbstractFileSystem):
         path = self._strip_protocol(path)
         repository, ref, prefix = parse(path)
 
-        try:
-            cache_entry: list[Any] | None = self._ls_from_cache(path)
-        except FileNotFoundError:
-            # we patch files missing from an ls call in the cache entry below,
-            # so this should not be an error.
-            cache_entry = None
+        # Try lookup in dircache unless explicitly disabled by `refresh=True` kwarg
+        use_dircache = True
+        if "refresh" in kwargs:
+            use_dircache = not kwargs["refresh"]
+            del kwargs["refresh"]  # cannot be forwarded to the API
 
-        if cache_entry is not None:
-            if not detail:
-                return [e["name"] for e in cache_entry]
-            return cache_entry
+        if use_dircache:
+            cache_entry: list[Any] | None = None
+            try:
+                cache_entry = self._ls_from_cache(path)
+            except FileNotFoundError:
+                # we patch files missing from an ls call in the cache entry below,
+                # so this should not be an error.
+                pass
+
+            if cache_entry is not None:
+                if not detail:
+                    return [e["name"] for e in cache_entry]
+                return cache_entry
 
         has_more, after = True, ""
         # stat infos are either the path only (`detail=False`) or a dict full of metadata

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -28,7 +28,7 @@ def test_ls_caching(fs: LakeFSFileSystem, repository: str) -> None:
     for _ in range(2):
         fs.ls(resource)
         assert len(fs.dircache) == 1
-        assert tuple(fs.dircache.keys()) == (testdir,)
+        assert set(fs.dircache.keys()) == {resource.removesuffix("/")}
 
     # assert the second `ls` call hits the cache
     assert counter.count("objects_api.list_objects") == 1
@@ -46,11 +46,13 @@ def test_ls_stale_cache_entry(
 
     resource = f"{repository}/main/data/"
 
-    fs.ls(resource)
+    res = fs.ls(resource)
     assert counter.count("objects_api.list_objects") == 1
-    assert tuple(fs.dircache.keys()) == ("data",)
+    assert set(fs.dircache.keys()) == {resource.removesuffix("/")}
 
-    cache_entry = fs.dircache["data"]
+    cache_entry = fs.dircache[resource.removesuffix("/")]
+    assert len(cache_entry) == 1
+    assert cache_entry[0] == res[0]
 
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/data/{random_file.name}"
@@ -59,26 +61,34 @@ def test_ls_stale_cache_entry(
 
     res = fs.ls(rpath)
     assert counter.count("objects_api.list_objects") == 2
-    # is the file now added to the cache entry?
-    assert res[0] in cache_entry
+
+    # Should not be added to the cache for the other branch...
+    assert len(cache_entry) == 1
+
+    # ... but instead to the cache entry for the new branch
+    cache_entry = fs.dircache[f"{repository}/{temp_branch}/data"]
+    assert len(cache_entry) == 1
+    assert cache_entry[0] == res[0]
 
 
 def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
     fs.client, counter = with_counter(fs.client)
 
-    resource = f"{repository}/main/data"
+    branch = "main"
+    prefix = f"{repository}/{branch}"
+    resource = f"{prefix}/data"
 
-    expected = ["data/lakes.source.md"]
+    expected = [f"{resource}/lakes.source.md"]
     # first, verify the API fetch does the expected...
     assert fs.ls(resource, detail=False) == expected
-    assert list(fs.dircache.keys()) == ["data"]
+    assert list(fs.dircache.keys()) == [resource]
 
     # ...as well as the cache fetch.
     assert fs.ls(resource, detail=False) == expected
     assert counter.count("objects_api.list_objects") == 1
 
     # test the same thing with a subfolder + file prefix
-    resource = f"{repository}/main/images/duckdb"
+    resource = f"{prefix}/images/duckdb"
     fs.ls(resource, detail=False)
 
-    assert list(fs.dircache.keys()) == ["data", "images"]
+    assert set(fs.dircache.keys()) == {f"{prefix}/data", f"{prefix}/images"}


### PR DESCRIPTION
This PR improves the implementation of the `ls` operation:

- Returned items include their fully-qualified (repo + ref) path (#162)
- Dircache can be bypassed explicitly by passing the `refresh=True` parameter (#163)
- Dircache keys take repo + ref into account (otherwise the cache would yield false hits for objects with the same path on different branches) (#164)