### PR TITLE
Docs: Add third-party integrations user guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,3 +6,4 @@ See the [Quickstart guide](../quickstart.md) for an introductory tutorial.
 - [How to use the lakeFS file system](filesystem-usage.md)
 - [Passing configuration to the file system](configuration.md)
 - [Using file system transactions](transactions.md)
+- [How to use `lakefs-spec` with third-party data science libraries](integrations.md)

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -38,7 +38,10 @@ with fs.transaction as tx:
 
 ## DuckDB
 
-Similar to the example above, the following code snippet illustrates how to read and write data from/to a lakeFS repository in the context of a [transaction](transactions.md) through the DuckDB Python API:
+The [DuckDB](https://duckdb.org/){: target="_blank" rel="noopener"} in-memory database management system includes support for `fsspec` file systems as part of its Python API (see the official documentation on [using fsspec filesystems](https://duckdb.org/docs/guides/python/filesystems.html){: target="_blank" rel="noopener"} for details).
+This allows DuckDB to transparently query and store data located in lakeFS repositories through `lakefs-spec`.
+
+Similar to the example above, the following code snippet illustrates how to read and write data from/to a lakeFS repository in the context of a [transaction](transactions.md) through the [DuckDB Python API](https://duckdb.org/docs/api/python/overview.html){: target="_blank" rel="noopener"}:
 
 ```python
 import duckdb

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -38,6 +38,32 @@ with fs.transaction as tx:
 
 ## DuckDB
 
+Similar to the example above, the following code snippet illustrates how to read and write data from/to a lakeFS repository in the context of a [transaction](transactions.md) through the DuckDB Python API:
+
+```python
+import duckdb
+
+from lakefs_spec import LakeFSFileSystem
+
+fs = LakeFSFileSystem()
+duckdb.register_filesystem(fs)  # (1)! 
+
+with fs.transaction as tx:
+    tx.create_branch("quickstart", "german-lakes", "main")
+
+    lakes = duckdb.read_parquet("lakefs://quickstart/main/lakes.parquet")
+    german_lakes = duckdb.sql("SELECT * FROM lakes where Country='Germany'")
+    german_lakes.to_csv("lakefs://quickstart/german-lakes/german_lakes.csv")
+
+    tx.commit("quickstart", "german-lakes", "Add German lakes")
+```
+
+1. Makes the `lakefs-spec` file system known to DuckDB (`duckdb.register_filesystem(fsspec.filesystem("lakefs"))` can also be used to avoid the direct import of `LakeFSFileSystem`)
+
 ## PyArrow
 
+!!! todo
+
 ## Polars
+
+!!! todo

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,0 +1,43 @@
+# How to use `lakefs-spec` with third-party data science libraries
+
+`lakefs-spec` is built on top of the `fsspec` library, which allows third-party libraries to make use of its file system abstraction to offer high-level features.
+The [`fsspec` documentation](https://filesystem-spec.readthedocs.io/en/latest/#who-uses-fsspec){: target="_blank" rel="noopener"} lists examples of its users, mostly data science libraries.
+
+This user guide page adds more detail on how `lakefs-spec` can be used with four prominent data science libraries.
+
+!!! tip "Code Examples"
+    The code examples assume access to an existing lakeFS server with a `quickstart` containing the sample data set repository set up.
+
+    Please see the [Quickstart guide](../quickstart.md) if you need guidance in getting started.
+
+## Pandas
+
+[Pandas](https://pandas.pydata.org){: target="_blank" rel="noopener"} can read and write data from remote locations, and uses `fsspec` for all URLs that are not local or HTTP(S).
+
+This means that (almost) all `pd.read_*` and `pd.DataFrame.to_*` operations can benefit from the lakeFS integration offered by our library without any additional configuration.
+See the Pandas documentation on [reading/writing remote files](https://pandas.pydata.org/docs/user_guide/io.html#reading-writing-remote-files){: target="_blank" rel="noopener"} for additional details.
+
+The following code snippet illustrates how to read and write Pandas data frames in various formats from/to a lakeFS repository in the context of a [transaction](transactions.md):
+
+```python
+import pandas as pd
+
+from lakefs_spec.transaction import LakeFSFileSystem
+
+fs = LakeFSFileSystem()
+
+with fs.transaction as tx:
+    tx.create_branch("quickstart", "german-lakes", "main")
+
+    lakes = pd.read_parquet("lakefs://quickstart/main/lakes.parquet")
+    german_lakes = lakes.query('Country == "Germany"')
+    german_lakes.to_csv("lakefs://quickstart/german-lakes/german_lakes.csv")
+
+    tx.commit("quickstart", "german-lakes", "Add German lakes")
+```
+
+## DuckDB
+
+## PyArrow
+
+## Polars

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -103,7 +103,7 @@ with fs.transaction as tx:
 
 PyArrow `read_*` and `write_*` functions take an explicit `filesystem` parameter, which accepts any `fsspec` file system, such as the `LakeFSFileSystem` provided by this library. 
 
-The following example code illustrates the use of `lakefs-spec` with PyArrow, reading a Parquet file and writing it back to a lakeFS repository as a partitioned dataset in the context of a [transaction](transactions.md):
+The following example code illustrates the use of `lakefs-spec` with PyArrow, reading a Parquet file and writing it back to a lakeFS repository as a partitioned CSV dataset in the context of a [transaction](transactions.md):
 
 ```python hl_lines="12 17"
 import pyarrow as pa
@@ -123,7 +123,7 @@ with fs.transaction as tx:
         lakes_table,
         "quickstart/partitioned-data/lakes",
         filesystem=fs,
-        format="parquet",
+        format="csv",
         partitioning=ds.partitioning(pa.schema([lakes_table.schema.field("Country")])),
     )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - guides/filesystem-usage.md
     - guides/configuration.md
     - guides/transactions.md
+    - guides/integrations.md
   - Tutorials:
     - tutorials/index.md
     - tutorials/demo_data_science_project.ipynb


### PR DESCRIPTION
This PR adds a page on the integration of lakefs-spec with third-party libraries to the user guide as `docs/guide/integrations.md`.

It includes explanations and code examples for:

- Pandas
- DuckDB
- Polars
- PyArrow

> [!NOTE]
> I wonder if the code examples should be included from external Python files, just as for the quickstart guide? This would allow us to run them as part of an integration test suite for the docs.