### PR TITLE
Add doc-strings to the client_helpers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
             show_bases: true
             members_order: source
             separate_signature: true
+            show_signature_annotations: true
             signature_crossrefs: true
             merge_init_into_class: false
   - mknotebooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,10 @@ nav:
 exclude_docs: |
   use-cases.md
 
+# Rebuild docs in `mkdocs serve` for changes in source code
+watch:
+  - src/
+
 plugins:
   - callouts
   - gen-files:

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -35,7 +35,8 @@ def commit(
     message: str,
     metadata: dict[str, str] | None = None,
 ) -> Commit:
-    """Creates a new commit of all uncommitted changes on the branch in the lakeFS file storage
+    """
+    Creates a new commit of all uncommitted changes on the branch in the lakeFS file storage
 
     Parameters
     -------
@@ -71,7 +72,8 @@ def commit(
 def create_branch(
     client: LakeFSClient, repository: str, name: str, source_branch: str, exist_ok: bool = True
 ) -> str:
-    """Creates a branch in a lakeFS repository.
+    """
+    Creates a branch in a lakeFS repository.
 
     Parameters
     ----------
@@ -112,7 +114,8 @@ def create_branch(
 def create_repository(
     client: LakeFSClient, name: str, storage_namespace: str, exist_ok: bool = True
 ) -> Repository:
-    """Creates a new repository in the lakeFS file storage system with a specified name and storage namespace.
+    """
+    Creates a new repository in the lakeFS file storage system with a specified name and storage namespace.
 
     Parameters
     ----------
@@ -150,7 +153,8 @@ def create_repository(
 def create_tag(
     client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = True
 ) -> Ref:
-    """Creates a new tag in the specified repository in the lakeFS file storage system.
+    """
+    Creates a new tag in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
@@ -188,7 +192,8 @@ def create_tag(
 
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
-    """Lists all the tags in the specified repository in the lakeFS file storage system.
+    """
+    Lists all the tags in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
@@ -205,7 +210,8 @@ def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
 
 
 def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch: str) -> None:
-    """Merges changes from a source reference to a target branch in a specified repository in the lakeFS file storage system.
+    """
+    Merges changes from a source reference to a target branch in a specified repository in the lakeFS file storage system.
     If no differences between source_ref and target_branch are found, the merge process is aborted.
 
     Parameters
@@ -231,7 +237,8 @@ def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch:
 
 
 def revert(client: LakeFSClient, repository: str, branch: str, parent_number: int = 1) -> None:
-    """Reverts the commit on the specified branch to the parent specified by parent_number.
+    """
+    Reverts the commit on the specified branch to the parent specified by parent_number.
 
     Parameters
     ----------
@@ -256,7 +263,8 @@ def rev_parse(
     ref: str | Commit,
     parent: int = 0,
 ) -> Commit:
-    """Resolves a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
+    """
+    Resolves a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
 
     Parameters
     ----------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -53,7 +53,8 @@ def commit(
 
     Returns
     -------
-        Commit: Commit object of the lakeFS-SDK.
+    Commit
+        Commit object of the lakeFS-SDK.
     """
     diff = client.branches_api.diff_branch(repository=repository, branch=branch)
 
@@ -90,12 +91,12 @@ def create_branch(
 
     Returns
     -------
-    name: str
+    str
         Name of newly created or existing.
 
     Raises
     ------
-    ApiException:
+    ApiException
         If a branch with the same name already exists and 'exist_ok' is set to False.
     """
 
@@ -130,11 +131,12 @@ def create_repository(
 
     Returns
     -------
-        Repository: Repository object of the lakeFS-SDK representing the newly created or existing repository.
+    Repository
+        Repository object of the lakeFS-SDK representing the newly created or existing repository.
 
     Raises
     ------
-    ApiException:
+    ApiException
         If a repository of the same name already exists and 'exist_ok' is set to False.
 
     Notes
@@ -171,12 +173,13 @@ def create_tag(
 
     Raises
     ------
-    ApiException:
+    ApiException
         If a tag of the same name already exists and 'exist_ok' is set to False.
 
     Returns
     -------
-        Ref: Ref object of the lakeFS-sdk representing the newly created or existing tag.
+    Ref
+        Ref object of the lakeFS-sdk representing the newly created or existing tag.
     """
 
     if isinstance(ref, Commit):
@@ -204,7 +207,8 @@ def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
 
     Returns
     -------
-        list[Ref]: Ref objects of the tag in the repository.
+    list[Ref]
+        Ref objects of the tag in the repository.
     """
     return client.tags_api.list_tags(repository=repository).results
 
@@ -279,11 +283,12 @@ def rev_parse(
 
     Returns
     -------
-        Commit: Commit object representing the resolved commit in the lakeFS repository.
+    Commit
+        Commit object representing the resolved commit in the lakeFS repository.
 
     Raises
     ------
-    ValueError:
+    ValueError
         - If 'parent' is negative.
         - If the specified number of parent commits exceeds the actual number of available parents.
         - If the provided 'ref' does not match any revision in the specified repository.

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -40,7 +40,7 @@ def commit(
     Parameters
     -------
     client: LakeFSClient
-        The lakeFS client object.
+        lakeFS client object.
     repository: str
         Repository name.
     branch: str
@@ -52,7 +52,7 @@ def commit(
 
     Returns
     -------
-        Commit: Commit object of the lakeFS-sdk
+        Commit: Commit object of the lakeFS-SDK.
     """
     diff = client.branches_api.diff_branch(repository=repository, branch=branch)
 
@@ -76,11 +76,11 @@ def create_branch(
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client configured for (and authenticated with) the target instance.
+        lakeFS client object.
     repository: str
         Repository name.
     name: str
-        Name of the newly created (or existing) branch.
+        Name of the branch to be created.
     source_branch: str
         Name of the source branch the new branch is created from.
     exist_ok: bool
@@ -112,17 +112,17 @@ def create_repository(
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client object used for interactions with the lakeFS server.
+        lakeFS client object.
     name: str
-        The name of the repository to be created. This must be unique within the lakeFS instance.
+        Name of the repository to be created. This must be unique within the lakeFS instance.
     storage_namespace: str
-        The storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., an S3 bucket) or a local namespace (e.g. local://<repo_name>)
+        Storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., S3 bucket) or a local namespace (e.g. local://<repo_name>).
     exist_ok: bool, optional
-        Flag to determine behavior when a repository with the specified name already exists. If True, the existing repository is returned without error. Defaults to True.
+        Ignores error if the repository already exists. Defaults to True.
 
     Returns
     -------
-        Repository: Repository object of the lakeFS-sdk representing the newly created or existing repository.
+        Repository: Repository object of the lakeFS-SDK representing the newly created or existing repository.
 
     Notes
     -----
@@ -145,15 +145,15 @@ def create_tag(
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client object used for interactions with the lakeFS server.
+        lakeFS client object.
     repository: str
-        The name of the repository where the tag will be created.
+        Name of the repository where the tag will be created.
     ref: str | Commit
-        A string representing the commit SHA or a Commit object to which the tag will point.
+        Commit SHA or Commit object of the commit to which the tag will point.
     tag: str
-        The name of the tag to be created.
+        Name of the tag to be created.
     exist_ok: bool, optional
-        Flag to determine behavior when a tag with the specified name already exists. If True, the existing tag is returned without error. The tag is not reassigned. Defaults to True.
+        Ignore error if the tag already exists. The tag is not reassigned. Defaults to True.
 
     Returns
     -------
@@ -178,13 +178,13 @@ def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client object used for interactions with the lakeFS server.
+        lakeFS client object.
     repository: str
-        The name of the repository from which to list the tags.
+        Name of the repository from which to list the tags.
 
     Returns
     -------
-        list[Ref]: A list of Ref objects, each representing a tag in the specified repository.
+        list[Ref]: Ref objects of the tag in the repository.
     """
     return client.tags_api.list_tags(repository=repository).results
 
@@ -196,13 +196,13 @@ def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch:
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client object used for interactions with the lakeFS server.
+        lakeFS client object.
     repository: str
-        The name of the repository where the merge will occur.
+        Name of the repository where the merge will occur.
     source_ref: str
-        The source reference (branch or reference/commit SHA) from which changes will be merged.
+        Source reference (branch name or ref/commit SHA) from which changes will be merged.
     target_branch: str
-        The target branch to which changes will be merged.
+        Target branch to which changes will be merged.
     """
     diff = client.refs_api.diff_refs(
         repository=repository, left_ref=target_branch, right_ref=source_ref
@@ -221,7 +221,7 @@ def revert(client: LakeFSClient, repository: str, branch: str, parent_number: in
     Parameters
     ----------
     client: LakeFSClient
-        The client to interact with.
+        lakeFS client object.
     repository: str
         Repository in which the specified branch is located.
     branch: str
@@ -246,17 +246,17 @@ def rev_parse(
     Parameters
     ----------
     client: LakeFSClient
-        The lakeFS client object used for interactions with the lakeFS server.
+        lakeFS client object.
     repository: str
-        The name of the repository where the commit will be searched.
+        Name of the repository where the commit will be searched.
     ref: str | Commit
-        The commit reference SHA or Commit object (with SHA stored in its 'id' attribute) to resolve.
+        Commit SHA or Commit object (with SHA stored in its 'id' attribute) to resolve.
     parent: int, optional
-        The number of parent commits to go back from the specified 'ref'. Defaults to 0, which means no parent traversal.
+        Number of parent commits to go back from the specified 'ref'. Defaults to 0, which means no parent traversal.
 
     Returns
     -------
-        Commit: A Commit object representing the resolved commit in the lakeFS repository.
+        Commit: Commit object representing the resolved commit in the lakeFS repository.
 
     Raises
     ------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -36,7 +36,7 @@ def commit(
     metadata: dict[str, str] | None = None,
 ) -> Commit:
     """
-    Creates a new commit of all uncommitted changes on the branch in the lakeFS file storage
+    Create a new commit of all uncommitted changes on the branch in the lakeFS file storage.
 
     Parameters
     -------
@@ -74,7 +74,7 @@ def create_branch(
     client: LakeFSClient, repository: str, name: str, source_branch: str, exist_ok: bool = True
 ) -> str:
     """
-    Creates a branch in a lakeFS repository.
+    Create a branch in a lakeFS repository.
 
     Parameters
     ----------
@@ -116,7 +116,7 @@ def create_repository(
     client: LakeFSClient, name: str, storage_namespace: str, exist_ok: bool = True
 ) -> Repository:
     """
-    Creates a new repository in the lakeFS file storage system with a specified name and storage namespace.
+    Create a new repository in the lakeFS file storage system with a specified name and storage namespace.
 
     Parameters
     ----------
@@ -156,7 +156,7 @@ def create_tag(
     client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = True
 ) -> Ref:
     """
-    Creates a new tag in the specified repository in the lakeFS file storage system.
+    Create a new tag in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
@@ -196,7 +196,7 @@ def create_tag(
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
     """
-    Lists all the tags in the specified repository in the lakeFS file storage system.
+    List all the tags in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
@@ -242,7 +242,7 @@ def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch:
 
 def revert(client: LakeFSClient, repository: str, branch: str, parent_number: int = 1) -> None:
     """
-    Reverts the commit on the specified branch to the parent specified by parent_number.
+    Revert the commit on the specified branch to the parent specified by parent_number.
 
     Parameters
     ----------
@@ -268,7 +268,7 @@ def rev_parse(
     parent: int = 0,
 ) -> Commit:
     """
-    Resolves a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
+    Resolve a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
 
     Parameters
     ----------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -97,7 +97,7 @@ def create_branch(
     Raises
     ------
     ApiException
-        If a branch with the same name already exists and 'exist_ok' is set to False.
+        If a branch with the same name already exists and ``exist_ok=False``.
     """
 
     try:
@@ -132,12 +132,12 @@ def create_repository(
     Returns
     -------
     Repository
-        Repository object of the lakeFS-SDK representing the newly created or existing repository.
+        Repository object of the lakeFS SDK representing the newly created or existing repository.
 
     Raises
     ------
     ApiException
-        If a repository of the same name already exists and 'exist_ok' is set to False.
+        If a repository of the same name already exists and ``exist_ok=False``.
 
     Notes
     -----
@@ -174,12 +174,12 @@ def create_tag(
     Raises
     ------
     ApiException
-        If a tag of the same name already exists and 'exist_ok' is set to False.
+        If a tag of the same name already exists and ``exist_ok=False``.
 
     Returns
     -------
     Ref
-        Ref object of the lakeFS-sdk representing the newly created or existing tag.
+        Ref object of the lakeFS SDK representing the newly created or existing tag.
     """
 
     if isinstance(ref, Commit):
@@ -277,9 +277,9 @@ def rev_parse(
     repository: str
         Name of the repository where the commit will be searched.
     ref: str | Commit
-        Commit SHA or Commit object (with SHA stored in its 'id' attribute) to resolve.
+        Commit SHA or Commit object (with SHA stored in its ``id`` attribute) to resolve.
     parent: int, optional
-        Number of parent commits to go back from the specified 'ref'. Defaults to 0, which means no parent traversal.
+        Number of parent commits to go back from the specified ``ref``. Defaults to 0, which means no parent traversal.
 
     Returns
     -------
@@ -289,9 +289,9 @@ def rev_parse(
     Raises
     ------
     ValueError
-        - If 'parent' is negative.
+        - If ``parent`` is negative.
         - If the specified number of parent commits exceeds the actual number of available parents.
-        - If the provided 'ref' does not match any revision in the specified repository.
+        - If the provided ``ref`` does not match any revision in the specified repository.
     """
     if parent < 0:
         raise ValueError(f"Parent cannot be negative, got {parent}")

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -26,8 +26,7 @@ def commit(
     message: str,
     metadata: dict[str, str] | None = None,
 ) -> Commit:
-    """
-    Creates a new commit of all uncommitted changes on the branch in the lakeFS file storage
+    """Creates a new commit of all uncommitted changes on the branch in the lakeFS file storage
 
     Parameters
     -------
@@ -63,8 +62,7 @@ def commit(
 def create_branch(
     client: LakeFSClient, repository: str, name: str, source_branch: str, exist_ok: bool = True
 ) -> str:
-    """
-    Create a branch in a lakeFS repository.
+    """Create a branch in a lakeFS repository.
 
     Parameters
     ----------
@@ -100,19 +98,18 @@ def create_branch(
 def create_repository(
     client: LakeFSClient, name: str, storage_namespace: str, exist_ok: bool = True
 ) -> Repository:
-    """
-    Creates a new repository in the lakeFS file storage system with a specified name and storage namespace.
+    """Creates a new repository in the lakeFS file storage system with a specified name and storage namespace.
 
     Parameters
     ----------
-        client: LakeFSClient
-            The lakeFS client object used for interactions with the lakeFS server.
-        name: str
-            The name of the repository to be created. This must be unique within the lakeFS instance.
-        storage_namespace: str
-            The storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., an S3 bucket) or a local namespace (e.g. local://<repo_name>)
-        exist_ok: bool, optional
-            Flag to determine behavior when a repository with the specified name already exists. If True, the existing repository is returned without error. Defaults to True.
+    client: LakeFSClient
+        The lakeFS client object used for interactions with the lakeFS server.
+    name: str
+        The name of the repository to be created. This must be unique within the lakeFS instance.
+    storage_namespace: str
+        The storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., an S3 bucket) or a local namespace (e.g. local://<repo_name>)
+    exist_ok: bool, optional
+        Flag to determine behavior when a repository with the specified name already exists. If True, the existing repository is returned without error. Defaults to True.
 
     Returns
     -------
@@ -134,21 +131,20 @@ def create_repository(
 def create_tag(
     client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = True
 ) -> Ref:
-    """
-    Creates a new tag in the specified repository in the lakeFS file storage system.
+    """Creates a new tag in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
-        client: LakeFSClient
-            The lakeFS client object used for interactions with the lakeFS server.
-        repository: str
-            The name of the repository where the tag will be created.
-        ref: str | Commit
-            A string representing the commit SHA or a Commit object to which the tag will point.
-        tag: str
-            The name of the tag to be created.
-        exist_ok: bool, optional
-            Flag to determine behavior when a tag with the specified name already exists. If True, the existing tag is returned without error. The tag is not reassigned. Defaults to True.
+    client: LakeFSClient
+        The lakeFS client object used for interactions with the lakeFS server.
+    repository: str
+        The name of the repository where the tag will be created.
+    ref: str | Commit
+        A string representing the commit SHA or a Commit object to which the tag will point.
+    tag: str
+        The name of the tag to be created.
+    exist_ok: bool, optional
+        Flag to determine behavior when a tag with the specified name already exists. If True, the existing tag is returned without error. The tag is not reassigned. Defaults to True.
 
     Returns
     -------
@@ -168,8 +164,7 @@ def create_tag(
 
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
-    """
-    Lists all the tags in the specified repository in the lakeFS file storage system.
+    """Lists all the tags in the specified repository in the lakeFS file storage system.
 
     Parameters
     ----------
@@ -186,8 +181,7 @@ def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
 
 
 def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch: str) -> None:
-    """
-    Merges changes from a source reference to a target branch in a specified repository in the lakeFS file storage system.
+    """Merges changes from a source reference to a target branch in a specified repository in the lakeFS file storage system.
     If no differences between source_ref and target_branch are found, the merge process is aborted.
 
     Parameters
@@ -238,8 +232,7 @@ def rev_parse(
     ref: str | Commit,
     parent: int = 0,
 ) -> Commit:
-    """
-    Resolves a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
+    """Resolves a commit reference to the most recent commit or traverses the specified number of parent commits on a branch in a lakeFS repository.
 
     Parameters
     ----------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -84,12 +84,17 @@ def create_branch(
     source_branch: str
         Name of the source branch the new branch is created from.
     exist_ok: bool
-        Ignore errors if the branch already exists.
+        If True, ignore errors and return name of the branch if the branch already exists. Defaults to True.
 
     Returns
     -------
     name: str
-        The requested branch name.
+        Name of newly created or existing.
+
+    Raises
+    ------
+    ApiException:
+        If a branch with the same name already exists and 'exist_ok' is set to False.
     """
 
     try:
@@ -118,11 +123,16 @@ def create_repository(
     storage_namespace: str
         Storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., S3 bucket) or a local namespace (e.g. local://<repo_name>).
     exist_ok: bool, optional
-        Ignores error if the repository already exists. Defaults to True.
+        If True, ignores error and returns the Repository object, if the repository already exists. Defaults to True.
 
     Returns
     -------
         Repository: Repository object of the lakeFS-SDK representing the newly created or existing repository.
+
+    Raises
+    ------
+    ApiException:
+        If a repository of the same name already exists and 'exist_ok' is set to False.
 
     Notes
     -----
@@ -153,7 +163,12 @@ def create_tag(
     tag: str
         Name of the tag to be created.
     exist_ok: bool, optional
-        Ignore error if the tag already exists. The tag is not reassigned. Defaults to True.
+        If True, ignore error and return Tag object corresponding to the tag, if the tag already exists. The tag is not reassigned. Defaults to True.
+
+    Raises
+    ------
+    ApiException:
+        If a tag of the same name already exists and 'exist_ok' is set to False.
 
     Returns
     -------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -141,7 +141,7 @@ def create_repository(
 
     Notes
     -----
-        Attempting to recreate a repository with the same name and storage namespace after previous deletion may lead to issues due to residual data, and is not recommended.
+    Attempting to recreate a repository with the same name and storage namespace after previous deletion may lead to issues due to residual data, and is not recommended.
     """
     try:
         repository_creation = RepositoryCreation(name=name, storage_namespace=storage_namespace)

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -62,7 +62,7 @@ def commit(
 def create_branch(
     client: LakeFSClient, repository: str, name: str, source_branch: str, exist_ok: bool = True
 ) -> str:
-    """Create a branch in a lakeFS repository.
+    """Creates a branch in a lakeFS repository.
 
     Parameters
     ----------

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -54,7 +54,7 @@ def commit(
     Returns
     -------
     Commit
-        The created commit object of the lakeFS server. 
+        The created commit object of the lakeFS server.
     """
     diff = client.branches_api.diff_branch(repository=repository, branch=branch)
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -54,7 +54,7 @@ def commit(
     Returns
     -------
     Commit
-        Commit object of the lakeFS-SDK.
+        The created commit object of the lakeFS server. 
     """
     diff = client.branches_api.diff_branch(repository=repository, branch=branch)
 
@@ -87,12 +87,12 @@ def create_branch(
     source_branch: str
         Name of the source branch the new branch is created from.
     exist_ok: bool
-        If True, ignore errors and return name of the branch if the branch already exists. Defaults to True.
+        Ignore creation errors if the branch already exists.
 
     Returns
     -------
     str
-        Name of newly created or existing.
+        Name of newly created or existing branch.
 
     Raises
     ------
@@ -127,7 +127,7 @@ def create_repository(
     storage_namespace: str
         Storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., S3 bucket) or a local namespace (e.g. local://<repo_name>).
     exist_ok: bool, optional
-        If True, ignores error and returns the Repository object, if the repository already exists. Defaults to True.
+        Ignore creation errors if the repository already exists.
 
     Returns
     -------
@@ -169,7 +169,7 @@ def create_tag(
     tag: str
         Name of the tag to be created.
     exist_ok: bool, optional
-        If True, ignore error and return Tag object corresponding to the tag, if the tag already exists. The tag is not reassigned. Defaults to True.
+        Ignore creation errors if the tag already exists. The tag is not reassigned.
 
     Raises
     ------
@@ -253,7 +253,7 @@ def revert(client: LakeFSClient, repository: str, branch: str, parent_number: in
     branch: str
         Branch on which the commit should be reverted.
     parent_number: int, optional
-        If there are multiple parents to a commit, specify to which parent the commit should be reverted. Index starts at 1. Defaults to 1.
+        If there are multiple parents to a commit, specify to which parent the commit should be reverted. Index starts at 1.
     """
     revert_creation = RevertCreation(ref=branch, parent_number=parent_number)
     client.branches_api.revert_branch(

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -1,3 +1,12 @@
+"""
+This module provides a collection of functions to interact with a lakeFS server using the lakeFS SDK.
+It includes functionalities to manage branches, repositories, commits, tags, and merge operations in
+a lakeFS instance.
+
+Note: Users of this module should have a configured and authenticated LakeFSClient instance, which is
+required input to all functions.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Add doc strings such that the `client_helpers` API are included in the documentation. 

This addresses https://github.com/aai-institute/lakefs-spec/issues/121

The question remains open whether we want doc-strings (and hence documentation) on all the members where I added them. Some might not be intended as public API. Refer to the linked issue for more details.