### PR TITLE
Allow leading `lakefs://` scheme in input paths

### DIFF
--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -39,10 +39,12 @@ def parse(path: str) -> tuple[str, str, str]:
     # https://docs.lakefs.io/understand/model.html#repository
     # Second regex is the branch: Only letters, digits, underscores
     # and dash, no leading dash
-    path_regex = re.compile(r"([a-z0-9][a-z0-9\-]{2,62})/(\w[\w\-]*)/(.*)")
+    path_regex = re.compile(r"(?:lakefs://)?([a-z0-9][a-z0-9\-]{2,62})/(\w[\w\-]*)/(.*)")
     results = path_regex.fullmatch(path)
     if results is None:
-        raise ValueError(f"expected path with structure <repo>/<ref>/<resource>, got {path!r}")
+        raise ValueError(
+            f"expected path with structure lakefs://<repo>/<ref>/<resource>, got {path!r}"
+        )
 
     repo, ref, resource = results.groups()
     return repo, ref, resource

--- a/tests/test_spec_utils.py
+++ b/tests/test_spec_utils.py
@@ -32,6 +32,13 @@ def test_path_parsing():
     assert ref == "a"
     assert resource == "resource.txt"
 
+    # case 5: well-formed path with leading lakefs:// scheme
+    path = "lakefs://my-repo/my-ref/resource.txt"
+    repo, ref, resource = parse(path)
+    assert repo == "my-repo"
+    assert ref == "my-ref"
+    assert resource == "resource.txt"
+
     # ----------------- Failure cases -------------------
     # repo name illegally begins with hyphen
     path = "-repo/my-ref/resource.txt"


### PR DESCRIPTION
Since the scheme is a part of the URI, it should be allowed in the parsing regex. This is achieved by adding an optional positive lookahead capture group.

This has the benefit that the scheme, since we don't need it, does not appear in the regex match groups, so all other code can stay unchanged.

Adds a regression test for scheme parsing.

Fixes #159.