### PR TITLE
Documentation cleanup [ENG-198]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `lakefs-spec`
+# Contributing to lakeFS-spec
 
 Thank you for your interest in contributing to this project!
 
@@ -80,12 +80,12 @@ hack/lock-deps.sh lakefs-sdk
 
 Improvements or additions to the project's documentation are highly appreciated.
 
-The documentation is based on the [`mkdocs`](https://mkdocs.org) and [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/) projects, see their homepages for in-depth guides on their features and usage. We use the [Numpy documentation style](https://numpydoc.readthedocs.io/en/latest/format.html) for Python docstrings.
+The documentation is based on the [MkDocs](http://mkdocs.org) and [Material for MkDocs (`mkdocs-material`)](https://squidfunk.github.io/mkdocs-material/) projects, see their homepages for in-depth guides on their features and usage. We use the [Numpy documentation style](https://numpydoc.readthedocs.io/en/latest/format.html) for Python docstrings.
 
 To build the documentation locally, you need to first install the optional `docs` dependencies from `requirements-docs.txt`,
 e.g., with `pip install -r requirements-docs.txt`. You can then start a local documentation server with `mkdocs serve`, or
 build the documentation into its output folder in `public/`.
 
-In order to maintain documentation for multiple versions of this library, we use the [`mike`](https://github.com/jimporter/mike) tool, which automatically maintains individual documentation builds per version and publishes them to the `gh-pages` branch.
+In order to maintain documentation for multiple versions of this library, we use the [mike](https://github.com/jimporter/mike) tool, which automatically maintains individual documentation builds per version and publishes them to the `gh-pages` branch.
 
 The GitHub CI pipeline automatically invokes `mike` as part of the release process with the correct version and updates the GitHub pages branch for the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Developing on `lakefs-spec`
+# Contributing to `lakefs-spec`
 
 Thank you for your interest in contributing to this project!
 
 We appreciate issue reports, pull requests for code and documentation,
 as well as any project-related communication through [GitHub Discussions](https://github.com/aai-institute/lakefs-spec/discussions).
 
-## Quickstart
+## Getting Started
 
 To get started with development, you can follow these steps:
 
@@ -73,7 +73,8 @@ If you want to update the `lakefs-sdk` dependency, for example, simply run:
 hack/lock-deps.sh lakefs-sdk
 ```
 
-⚠️ Since the official development version is Python 3.11, please run the above commands in a virtual environment with Python 3.11.
+> [!IMPORTANT]
+> Since the official development version is Python 3.11, please run the above commands in a virtual environment with Python 3.11.
 
 ## Working on Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 [![](https://img.shields.io/pypi/v/lakefs-spec)](https://pypi.org/project/lakefs-spec) ![GitHub](https://img.shields.io/github/license/aai-institute/lakefs-spec) [![docs](https://img.shields.io/badge/docs-latest-blue)](https://lakefs-spec.org)
  ![GitHub](https://img.shields.io/github/stars/aai-institute/lakefs-spec)
 
-# `lakefs-spec`: An `fsspec` backend for lakeFS
+# lakeFS-spec: An fsspec backend for lakeFS
 
-Welcome to `lakefs-spec`, a [filesystem-spec](https://github.com/fsspec/filesystem_spec) backend implementation for the [lakeFS](https://lakefs.io/) data lake.
+Welcome to lakeFS-spec, a [filesystem-spec](https://github.com/fsspec/filesystem_spec) backend implementation for the [lakeFS](https://lakefs.io/) data lake.
 Our primary goal is to streamline versioned data operations in lakeFS, enabling seamless integration with popular data science tools such as Pandas, Polars, and DuckDB directly from Python.
 
 Highlights:
 
 - High-level abstraction over basic lakeFS repository operations
-- Seamless integration into the `fsspec` ecosystem
+- Seamless integration into the fsspec ecosystem
 - Transaction support
 - Zero-config option through config autodiscovery
 - Automatic up-/download management to avoid unnecessary transfers for unchanged files
 
 ## Installation
 
-`lakefs-spec` is published on PyPI, you can simply install it using your favorite package manager:
+lakeFS-spec is published on PyPI, you can simply install it using your favorite package manager:
 
 ```shell
 $ pip install lakefs-spec
@@ -26,11 +26,11 @@ $ poetry add lakefs-spec
 
 ## Usage
 
-The following usage examples showcase two major ways of using `lakefs-spec`: as a low-level filesystem abstraction, and through third-party (data science) libraries.
+The following usage examples showcase two major ways of using lakeFS-spec: as a low-level filesystem abstraction, and through third-party (data science) libraries.
 
-For a more thorough overview of the features and use cases for `lakefs-spec`, see the [user guide](https://lakefs-spec.org/latest/guides/overview/) and [tutorials](https://lakefs-spec.org/latest/guides/tutorials/) sections in the documentation.
+For a more thorough overview of the features and use cases for lakeFS-spec, see the [user guide](https://lakefs-spec.org/latest/guides/overview/) and [tutorials](https://lakefs-spec.org/latest/guides/tutorials/) sections in the documentation.
 
-### Low-level: As a `fsspec` filesystem 
+### Low-level: As a fsspec filesystem 
 
 The following example shows how to upload a file, create a commit, and read back the committed data using the bare lakeFS filesystem implementation.
 It assumes you have already created a repository named `repo` and have `lakectl` credentials set up on your machine in `~/.lakectl.yaml` (see the [lakeFS quickstart guide](https://docs.lakefs.io/quickstart/) if you are new to lakeFS and need guidance).
@@ -61,7 +61,7 @@ print(f.readline())  # "Hello, lakeFS!"
 
 ### High-level: Via third-party libraries
 
-A variety of widely-used data science tools are building on `fsspec` to access remote storage resources and can thus work with lakeFS data lakes directly through `lakefs-spec` (see the [`fsspec` docs](https://filesystem-spec.readthedocs.io/en/latest/#who-uses-fsspec) for details).
+A variety of widely-used data science tools are building on fsspec to access remote storage resources and can thus work with lakeFS data lakes directly through lakeFS-spec (see the [fsspec docs](https://filesystem-spec.readthedocs.io/en/latest/#who-uses-fsspec) for details).
 The examples assume you have a lakeFS instance with the [`quickstart` repository](https://docs.lakefs.io/quickstart/launch.html) containing sample data available.
 
 ```python
@@ -97,4 +97,4 @@ For information on the general development workflow, see the [contribution guide
 
 ## License
 
-The `lakefs-spec` library is distributed under the [Apache-2 license](https://github.com/aai-institute/lakefs-spec/blob/main/LICENSE).
+The lakeFS-spec library is distributed under the [Apache-2 license](https://github.com/aai-institute/lakefs-spec/blob/main/LICENSE).

--- a/docs/_styles/extra.css
+++ b/docs/_styles/extra.css
@@ -19,3 +19,11 @@ table {
 .landing-page-icon:hover {
     color: var(--md-accent-fg-color);
 }
+
+.celltag_remove_input,
+.celltag_remove_output,
+.celltag_Remove_input,
+.celltag_Remove_all_output,
+.celltag_Remove_single_output {
+    display: none !important
+}

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -5,13 +5,13 @@ This guide introduces them in the order of least to most in-Python configuration
 
 !!! Info
     
-    The configuration methods are introduced in reverse order of precedence - config file arguments have the lowest priority, environment variables have medium priority, and constructor arguments have the highest priority.
+    The configuration methods are introduced in reverse order of precedence - config file arguments have the lowest priority and are overwritten by environment variables (if specified).
 
 ## The `.lakectl.yaml` configuration file
 
 The easiest way of configuring the lakeFS file system is with a `lakectl` YAML configuration file. To address a lakeFS server, the following minimum configuration is required:
 
-```yaml
+```yaml title="~/.lakectl.yaml"
 credentials:
   access_key_id: <ID>
   secret_access_key: <KEY>
@@ -21,7 +21,7 @@ server:
 
 For a local instance produced by the [quickstart](../quickstart.md), the following values will work:
 
-```yaml
+```yaml title="~/.lakectl.yaml"
 credentials:
   access_key_id: AKIAIOSFOLQUICKSTART
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -66,7 +66,7 @@ fs = LakeFSFileSystem()
 
 !!! Info
     
-    Not all initialization values can be set via environment variables - the `proxy`, `create_branch_ok`, `source_branch`, and `storage_options` arguments can only be supplied in Python.
+    Not all initialization values can be set via environment variables - the `proxy`, `create_branch_ok`, and `source_branch` arguments can only be supplied in Python.
 
 ## Appendix: Mixing zero-config methods
 
@@ -76,7 +76,7 @@ However, care must be taken when working with different file systems configured 
 The reason for this is the [instance caching mechanism](https://filesystem-spec.readthedocs.io/en/latest/features.html#instance-caching) built into `fsspec`.
 While this allows for efficient reuse of file systems e.g. by third-party libraries (pandas, DuckDB, ...), it can lead to silent misconfigurations. Consider this example, with an existent `.lakectl.yaml` file:
 
-```yaml title="$HOME/.lakectl.yaml"
+```yaml title="~/.lakectl.yaml"
 credentials:
   access_key_id: AKIAIOSFOLQUICKSTART
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -68,22 +68,6 @@ fs = LakeFSFileSystem()
     
     Not all initialization values can be set via environment variables - the `proxy`, `create_branch_ok`, `source_branch`, and `storage_options` arguments can only be supplied in Python.
 
-## Using constructor arguments
-
-The most straightforward way is to simply supply the values to your lakeFS file system in Python:
-
-```python
-from lakefs_spec import LakeFSFileSystem
-
-fs = LakeFSFileSystem(
-    host="http://my-lakefs.host",
-    username="my-username",
-    password="my-password",
-)
-```
-
-Beware that this method of configuration can leak sensitive information when using fixed, constant values and checking them into version control systems.
-
 ## Appendix: Mixing zero-config methods
 
 Two of the introduced methods allow for "zero-config" (i.e. no arguments given to the constructor) initialization of the file system.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -73,7 +73,7 @@ fs = LakeFSFileSystem()
 Two of the introduced methods allow for "zero-config" (i.e. no arguments given to the constructor) initialization of the file system.
 However, care must be taken when working with different file systems configured by the same means (for example, file systems configured with separate environment variables).
 
-The reason for this is the [instance caching mechanism](https://filesystem-spec.readthedocs.io/en/latest/features.html#instance-caching) built into `fsspec`.
+The reason for this is the [instance caching mechanism](https://filesystem-spec.readthedocs.io/en/latest/features.html#instance-caching) built into fsspec.
 While this allows for efficient reuse of file systems e.g. by third-party libraries (pandas, DuckDB, ...), it can lead to silent misconfigurations. Consider this example, with an existent `.lakectl.yaml` file:
 
 ```yaml title="~/.lakectl.yaml"

--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -15,7 +15,7 @@ For example, the URI `repo/main/data/` (note the trailing slash) refers to the `
 ## On staged versus committed changes
 
 When uploading, copying, or removing files or directories from a branch, those removal operations will result in staged changes in the repository until a commit is created.
-`lakefs-spec` does not create these commits automatically, since it separates file operations from versioning operations rigorously.
+lakeFS-spec does not create these commits automatically, since it separates file operations from versioning operations rigorously.
 If you want to conduct versioning operations, like creating commits, between file transfers, the best way to do so is by using [filesystem transactions](transactions.md).
 
 ## How to use lakeFS file system APIs
@@ -23,7 +23,7 @@ If you want to conduct versioning operations, like creating commits, between fil
 The following section explains more in-depth how to use the `LakeFSFileSystem` APIs.
 This section concerns the explicitly implemented operations. In addition, there are a number of file system APIs inherited from the [`AbstractFileSystem` interface in fsspec](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
 
-More information on file system usage can be found in the [`fsspec` documentation](https://filesystem-spec.readthedocs.io/en/latest/usage.html#use-a-file-system).
+More information on file system usage can be found in the [fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/usage.html#use-a-file-system).
 
 ### Uploading and downloading files
 

--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -5,12 +5,12 @@ This guide contains instructions and code snippets on how to use the lakeFS file
 ## The lakeFS URI structure
 
 In the following subsections, we frequently make use of [lakeFS URIs](https://docs.lakefs.io/understand/model.html#lakefs-protocol-uris) in the example code.
-lakeFS URIs identify resources in a lakeFS deployment through a unique path consisting of repository name, lakeFS revision/ref name, and file name relative to the repository root.
+lakeFS URIs identify resources in a lakeFS deployment through a unique path consisting of repository name, lakeFS revision/ref name, and file name relative to the repository root. Optionally, they may be prefixed with the `lakefs://` URI scheme (this is required when using [third-party libraries](integrations.md)).
 
 As an example, a URI like `repo/main/file.txt` addresses the `file.txt` file on the `main` branch in the repository named `repo`.
 
 In some lakeFS file system operations, directories are also allowed as resource names.
-For example, the URI `repo/main/data/` (note the trailing slash) refers to the `data` directory on the `main` branch in the `repo` repository.
+For example, the URI `repo/main/data/` (note the optional trailing slash) refers to the `data` directory on the `main` branch in the `repo` repository.
 
 ## On staged versus committed changes
 
@@ -67,7 +67,7 @@ fs.put("dir", "my-repo/my-ref/dir", recursive=True)
     fs.put_file("my-repo/my-ref/file.txt", "file.txt", use_blockstore=True)
     ```
 
-    Direct lakeFS blockstore uploads require the installation of the corresponding `fsspec` file system implementation through `pip`.
+    Direct lakeFS blockstore uploads require the installation of the corresponding fsspec file system implementation through `pip`.
     For an S3-based lakeFS deployment, install the `s3fs` package. For Google Cloud Storage (GCS), install the `gcsfs` package.
     For Azure blob storage, install the `adlfs` package.
 

--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -47,10 +47,11 @@ If you want to upload an entire directory to lakeFS, you can use the `fs.put()` 
 
 ```python
 # structure:
-#   dir/a.txt
-#      /b.yaml
-#      /c.csv
-#      /...
+#   dir/
+#   ├── a.txt
+#   ├── b.yaml
+#   ├── c.csv
+#   └── ...
 
 fs.put("dir", "my-repo/my-ref/dir", recursive=True)
 ```
@@ -88,10 +89,11 @@ In the case of a directory in lakeFS, use the `fs.get()` API together with the `
 
 ```python
 # structure:
-#   dir/a.txt
-#      /b.yaml
-#      /c.csv
-#      /...
+#   dir/
+#   ├── a.txt
+#   ├── b.yaml
+#   ├── c.csv
+#   └── ...
 
 # downloads the entire `dir` directory (and subdirectories) into the current directory.
 fs.get("my-repo/my-ref/dir", "dir", recursive=True)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,9 +1,9 @@
 # User Guide
 
-The `lakefs-spec` user guide provides documentation for users of the library looking to solve specific tasks.
+The lakeFS-spec user guide provides documentation for users of the library looking to solve specific tasks.
 See the [Quickstart guide](../quickstart.md) for an introductory tutorial.
 
 - [How to use the lakeFS file system](filesystem-usage.md)
 - [Passing configuration to the file system](configuration.md)
 - [Using file system transactions](transactions.md)
-- [How to use `lakefs-spec` with third-party data science libraries](integrations.md)
+- [How to use lakeFS-spec with third-party data science libraries](integrations.md)

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,20 +1,20 @@
-# How to use `lakefs-spec` with third-party data science libraries
+# How to use lakeFS-spec with third-party data science libraries
 
-`lakefs-spec` is built on top of the `fsspec` library, which allows third-party libraries to make use of its file system abstraction to offer high-level features.
-The [`fsspec` documentation](https://filesystem-spec.readthedocs.io/en/latest/#who-uses-fsspec){: target="_blank" rel="noopener"} lists examples of its users, mostly data science libraries.
+lakeFS-spec is built on top of the fsspec library, which allows third-party libraries to make use of its file system abstraction to offer high-level features.
+The [fsspec documentation](https://filesystem-spec.readthedocs.io/en/latest/#who-uses-fsspec){: target="_blank" rel="noopener"} lists examples of its users, mostly data science libraries.
 
-This user guide page adds more detail on how `lakefs-spec` can be used with four prominent data science libraries.
+This user guide page adds more detail on how lakeFS-spec can be used with four prominent data science libraries.
 
 !!! tip "Code Examples"
     The code examples assume access to an existing lakeFS server with a `quickstart` containing the sample data set repository set up.
 
     Please see the [Quickstart guide](../quickstart.md) if you need guidance in getting started.
 
-    The relevant lines for the `lakefs-spec` integration in these examples are highlighted.
+    The relevant lines for the lakeFS-spec integration in these examples are highlighted.
 
 ## Pandas
 
-[Pandas](https://pandas.pydata.org){: target="_blank" rel="noopener"} can read and write data from remote locations, and uses `fsspec` for all URLs that are not local or HTTP(S).
+[Pandas](https://pandas.pydata.org){: target="_blank" rel="noopener"} can read and write data from remote locations, and uses fsspec for all URLs that are not local or HTTP(S).
 
 This means that (almost) all `pd.read_*` and `pd.DataFrame.to_*` operations can benefit from the lakeFS integration offered by our library without any additional configuration.
 See the Pandas documentation on [reading/writing remote files](https://pandas.pydata.org/docs/user_guide/io.html#reading-writing-remote-files){: target="_blank" rel="noopener"} for additional details.
@@ -40,8 +40,8 @@ with fs.transaction as tx:
 
 ## DuckDB
 
-The [DuckDB](https://duckdb.org/){: target="_blank" rel="noopener"} in-memory database management system includes support for `fsspec` file systems as part of its Python API (see the official documentation on [using fsspec filesystems](https://duckdb.org/docs/guides/python/filesystems.html){: target="_blank" rel="noopener"} for details).
-This allows DuckDB to transparently query and store data located in lakeFS repositories through `lakefs-spec`.
+The [DuckDB](https://duckdb.org/){: target="_blank" rel="noopener"} in-memory database management system includes support for fsspec file systems as part of its Python API (see the official documentation on [using fsspec filesystems](https://duckdb.org/docs/guides/python/filesystems.html){: target="_blank" rel="noopener"} for details).
+This allows DuckDB to transparently query and store data located in lakeFS repositories through lakeFS-spec.
 
 Similar to the example above, the following code snippet illustrates how to read and write data from/to a lakeFS repository in the context of a [transaction](transactions.md) through the [DuckDB Python API](https://duckdb.org/docs/api/python/overview.html){: target="_blank" rel="noopener"}:
 
@@ -63,15 +63,15 @@ with fs.transaction as tx:
     tx.commit("quickstart", "german-lakes", "Add German lakes")
 ```
 
-1. Makes the `lakefs-spec` file system known to DuckDB (`duckdb.register_filesystem(fsspec.filesystem("lakefs"))` can also be used to avoid the direct import of `LakeFSFileSystem`)
+1. Makes the lakeFS-spec file system known to DuckDB (`duckdb.register_filesystem(fsspec.filesystem("lakefs"))` can also be used to avoid the direct import of `LakeFSFileSystem`)
 
 ## Polars
 
 !!! warning
-    There is an ongoing discussion in the Polars development team whether to remove support for `fsspec` file systems, with no clear outcome as of the time this page was written.
+    There is an ongoing discussion in the Polars development team whether to remove support for fsspec file systems, with no clear outcome as of the time this page was written.
     Please refer to the discussion on the relevant [GitHub issue](https://github.com/pola-rs/polars/issues/11056){: target="_blank" rel="noopener"} in case you encounter any problems.
 
-The Python API wrapper for the Rust-based [Polars](https://pola-rs.github.io/polars/){: target="_blank" rel="noopener"} DataFrame library can access remote storage through `fsspec`, similar to Pandas (see the official [documentation on cloud storage](https://pola-rs.github.io/polars/user-guide/io/cloud-storage/){: target="_blank" rel="noopener"}).
+The Python API wrapper for the Rust-based [Polars](https://pola-rs.github.io/polars/){: target="_blank" rel="noopener"} DataFrame library can access remote storage through fsspec, similar to Pandas (see the official [documentation on cloud storage](https://pola-rs.github.io/polars/user-guide/io/cloud-storage/){: target="_blank" rel="noopener"}).
 
 Again, the following code example demonstrates how to read a Parquet file and save a modified version back in CSV format to a lakeFS repository from Polars in the context of a  [transaction](transactions.md):
 
@@ -99,11 +99,11 @@ with fs.transaction as tx:
 
 ## PyArrow
 
-[Apache Arrow](https://arrow.apache.org/){: target="_blank" rel="noopener"} and its Python API, [PyArrow](https://arrow.apache.org/docs/python/){: target="_blank" rel="noopener"}, can also use `fsspec` file systems to perform I/O operations on data objects. The documentation has additional details on [using fsspec-compatible file systems with Arrow](https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems-with-arrow){: target="_blank" rel="noopener"}.
+[Apache Arrow](https://arrow.apache.org/){: target="_blank" rel="noopener"} and its Python API, [PyArrow](https://arrow.apache.org/docs/python/){: target="_blank" rel="noopener"}, can also use fsspec file systems to perform I/O operations on data objects. The documentation has additional details on [using fsspec-compatible file systems with Arrow](https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems-with-arrow){: target="_blank" rel="noopener"}.
 
-PyArrow `read_*` and `write_*` functions take an explicit `filesystem` parameter, which accepts any `fsspec` file system, such as the `LakeFSFileSystem` provided by this library. 
+PyArrow `read_*` and `write_*` functions take an explicit `filesystem` parameter, which accepts any fsspec file system, such as the `LakeFSFileSystem` provided by this library. 
 
-The following example code illustrates the use of `lakefs-spec` with PyArrow, reading a Parquet file and writing it back to a lakeFS repository as a partitioned CSV dataset in the context of a [transaction](transactions.md):
+The following example code illustrates the use of lakeFS-spec with PyArrow, reading a Parquet file and writing it back to a lakeFS repository as a partitioned CSV dataset in the context of a [transaction](transactions.md):
 
 ```python hl_lines="12 17"
 import pyarrow as pa

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,11 +20,6 @@ Highlights:
   icon: ":octicons-flame-24:{ .landing-page-icon }"
   url: quickstart.md
 
-- title: Use Cases
-  content: Reasons to use lakefs-spec in your project
-  icon: ":octicons-telescope-24:{ .landing-page-icon }"
-  url: use-cases.md
-
 - title: Tutorials
   content: In-depth tutorials on using lakefs-spec
   icon: ":octicons-repo-clone-24:{ .landing-page-icon }"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 # lakefs-spec: An fsspec backend for lakeFS
 
-Welcome to `lakefs-spec`, a [filesystem-spec](https://github.com/fsspec/filesystem_spec) backend implementation for the [lakeFS](https://lakefs.io/) data lake.
+Welcome to lakeFS-spec, a [filesystem-spec](https://github.com/fsspec/filesystem_spec) backend implementation for the [lakeFS](https://lakefs.io/) data lake.
 Our primary goal is to streamline versioned data operations in lakeFS, enabling seamless integration with popular data science tools such as Pandas, Polars, and DuckDB directly from Python.
 
 Highlights:
 
 - High-level abstraction over basic lakeFS repository operations
-- Seamless integration into the `fsspec` ecosystem
+- Seamless integration into the fsspec ecosystem
 - Transaction support
 - Zero-config option through config autodiscovery
 - Automatic up-/download management to avoid unnecessary transfers for unchanged files

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,25 +1,25 @@
 # Quickstart
 
-Welcome! This quickstart guide will get you up and running with `lakefs-spec` by showing you how to
+Welcome! This quickstart guide will get you up and running with lakeFS-spec by showing you how to
 
 1. [install the `lakefs-spec` package](#installing),
 1. [spin up a local lakeFS server](#spinning-up-a-local-lakefs-instance),
 1. [create a lakeFS repository for experimentation](#create-a-lakefs-repository), and
 1. [perform basic file system operations](#using-the-lakefs-fsspec-file-system)
-in a lakeFS repository using `lakefs-spec`.
+in a lakeFS repository using lakeFS-spec.
 
 ??? info "Prerequisites"
 
     To follow along with this guide, you will need a few prerequisites ready on your machine:
 
-    - `lakefs-spec` supports Windows, macOS, or Linux
+    - lakeFS-spec supports Windows, macOS, or Linux
     - [Docker](https://www.docker.com/get-started/), with Docker Compose
     - [Python 3.9](https://python.org) or later
     - optionally, [`lakectl`](https://docs.lakefs.io/reference/cli.html), the lakeFS command line tool
 
     Please take a moment to make sure you have these tools available before proceeding with the next steps.
 
-## Installing `lakefs-spec`
+## Installing lakeFS-spec
 
 ??? tip "A note on virtual environments"
 
@@ -68,7 +68,7 @@ Or, if you want to try the latest pre-release version directly from GitHub:
 
 If you don't already have access to a lakeFS server, you can quickly start a local instance using Docker Compose. Before continuing, please make sure Docker is installed and running on your machine.
 
-The lakeFS quickstart deployment can be launched directly with a [configuration file](https://github.com/aai-institute/lakefs-spec/blob/main/hack/docker-compose.yml) provided in the `lakefs-spec` repository:
+The lakeFS quickstart deployment can be launched directly with a [configuration file](https://github.com/aai-institute/lakefs-spec/blob/main/hack/docker-compose.yml) provided in the lakeFS-spec repository:
 
 ```shell
 $ curl https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/docker-compose.yml | docker-compose -f - up
@@ -80,7 +80,7 @@ If you do not have `curl` installed on your machine or would like to examine and
 --8<-- "https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/docker-compose.yml:3:"
 ```
 
-In order to allow `lakefs-spec` to automatically discover credentials to access this lakeFS instance, create a `.lakectl.yaml` in your home directory containing the credentials for the quickstart environment (you can also use `lakectl config` to create this file interactively if you have the `lakectl` tool installed on your machine):
+In order to allow lakeFS-spec to automatically discover credentials to access this lakeFS instance, create a `.lakectl.yaml` in your home directory containing the credentials for the quickstart environment (you can also use `lakectl config` to create this file interactively if you have the `lakectl` tool installed on your machine):
 
 ```yaml title="~/.lakectl.yaml"
 credentials: # (1)!
@@ -113,11 +113,11 @@ Click the small _Click here_ link at the bottom of the page to proceed and creat
     ![](_images/quickstart-lakefs-repositories.png)
 
 !!! success
-    You have successfully created a lakeFS repository named `repo`, ready to be used with `lakefs-spec`.
+    You have successfully created a lakeFS repository named `repo`, ready to be used with lakeFS-spec.
 
-### Using the lakeFS `fsspec` file system
+### Using the lakeFS file system
 
-We will now use the `lakefs-spec` file system interface to perform some basic operations on the repository created in the previous step:
+We will now use the lakeFS-spec file system interface to perform some basic operations on the repository created in the previous step:
 
 * Upload a local file to the repository
 * Read data from a file in the repository
@@ -153,7 +153,7 @@ While examining the file contents in the browser is nice, we want to access the 
 
 Note that executing the same code multiple times will only result in a single commit in the repository since the contents of the file on disk and in the repository are identical.
 
-In addition to simple read and write operations, the `fsspec` file system interface also allows us to list the files in a repository folder using `ls`, and query the metadata of objects in the repository through `info` (akin to the POSIX `stat` system call).
+In addition to simple read and write operations, the fsspec file system interface also allows us to list the files in a repository folder using `ls`, and query the metadata of objects in the repository through `info` (akin to the POSIX `stat` system call).
 Let's add the following code to our script and observe the output:
 
 ```python
@@ -168,7 +168,7 @@ As the last order of business, let's clean up the repository to its original sta
 
 !!! success
 
-    You now have all the basic tools available to version data from your Python code using the file system interface provided by `lakefs-spec`.
+    You now have all the basic tools available to version data from your Python code using the file system interface provided by lakeFS-spec.
 
 ??? tip "Full example code"
 
@@ -178,10 +178,10 @@ As the last order of business, let's clean up the repository to its original sta
 
 ## Next Steps
 
-After this walkthrough of the installation and an introduction to basic file system operations using `lakefs-spec`, you might want to consider more advanced topics:
+After this walkthrough of the installation and an introduction to basic file system operations using lakeFS-spec, you might want to consider more advanced topics:
 
 - [API Reference](reference/lakefs_spec/spec.md)
 - [User Guide](guides/index.md), in particular
     - [How to use the lakeFS file system](guides/filesystem-usage.md)
-    - [How to use `lakefs-spec` with third-party data science libraries](guides/integrations.md)
-- [Tutorial: Using `lakefs-spec` in a data science project](tutorials/demo_data_science_project.ipynb)
+    - [How to use lakeFS-spec with third-party data science libraries](guides/integrations.md)
+- [Tutorial: Using lakeFS-spec in a data science project](tutorials/demo_data_science_project.ipynb)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 Welcome! This quickstart guide will get you up and running with `lakefs-spec` by showing you how to
 
-1. [Install the `lakefs-spec` package](#installing),
+1. [install the `lakefs-spec` package](#installing),
 1. [spin up a local lakeFS server](#spinning-up-a-local-lakefs-instance),
 1. [create a lakeFS repository for experimentation](#create-a-lakefs-repository), and
 1. [perform basic file system operations](#using-the-lakefs-fsspec-file-system)
@@ -13,7 +13,7 @@ in a lakeFS repository using `lakefs-spec`.
     To follow along with this guide, you will need a few prerequisites ready on your machine:
 
     - `lakefs-spec` supports Windows, macOS, or Linux
-    - [Docker](https://www.docker.com/get-started/), with Docker Compose (Podman should work as well, but is untested)
+    - [Docker](https://www.docker.com/get-started/), with Docker Compose
     - [Python 3.9](https://python.org) or later
     - optionally, [`lakectl`](https://docs.lakefs.io/reference/cli.html), the lakeFS command line tool
 
@@ -178,11 +178,10 @@ As the last order of business, let's clean up the repository to its original sta
 
 ## Next Steps
 
-!!! todo
-    These links might refer to pages under development and are subject to change (or being broken)
-
 After this walkthrough of the installation and an introduction to basic file system operations using `lakefs-spec`, you might want to consider more advanced topics:
 
-- [Use Cases for `lakefs-spec`](use-cases.md)
 - [API Reference](reference/lakefs_spec/spec.md)
-- [TODO: User Guide](guides/index.md)
+- [User Guide](guides/index.md), in particular
+    - [How to use the lakeFS file system](guides/filesystem-usage.md)
+    - [How to use `lakefs-spec` with third-party data science libraries](guides/integrations.md)
+- [Tutorial: Using `lakefs-spec` in a data science project](tutorials/demo_data_science_project.ipynb)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -3,5 +3,5 @@
 !!! info
     We aim to provide additional tutorials in the future - contributions are welcome!
 
-- [Quickstart example](../quickstart.md): Using `lakefs-spec` as a file system
-- [A fully-worked data science example](demo_data_science_project.ipynb): Using `lakefs-spec` together with Pandas to train a classifier based on a public dataset and simulate additional data being collected
+- [Quickstart example](../quickstart.md): Using lakeFS-spec as a file system
+- [A fully-worked data science example](demo_data_science_project.ipynb): Using lakeFS-spec together with Pandas to train a classifier based on a public dataset and simulate additional data being collected

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,4 +1,4 @@
-# Useful resources for development on `lakefs-spec`
+# Useful resources for development on lakeFS-spec
 
 This document contains information on the resources in this directory, and how they can be used in development and testing.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,6 @@ copyright: Copyright &copy; 2023 <a href="https://appliedai-institute.de" target
 nav:
   - Home: index.md
   - quickstart.md
-  - Use Cases: use-cases.md
   - User Guide:
     - guides/index.md
     - guides/filesystem-usage.md
@@ -31,6 +30,9 @@ nav:
     - tutorials/demo_data_science_project.ipynb
   - API Reference: reference/
   - CONTRIBUTING.md
+
+exclude_docs: |
+  use-cases.md
 
 plugins:
   - gen-files:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,12 +29,13 @@ nav:
     - tutorials/index.md
     - tutorials/demo_data_science_project.ipynb
   - API Reference: reference/
-  - CONTRIBUTING.md
+  - Contributing: CONTRIBUTING.md
 
 exclude_docs: |
   use-cases.md
 
 plugins:
+  - callouts
   - gen-files:
       scripts:
         - docs/_scripts/gen_api_ref_pages.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
 ]
 docs = [
     "mkdocs",
+    "mkdocs-callouts",
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
     "mkdocs-section-index",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -77,6 +77,7 @@ mike==2.0.0
 mistune==3.0.2
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
+mkdocs-callouts==1.10.0
 mkdocs-gen-files==0.5.0
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-include-dir-to-nav==1.2.0

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -60,7 +60,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         **storage_options: Any,
     ):
         """
-        The LakeFS file system constructor.
+        The lakeFS file system constructor.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR should bring the documentation to a release-ready state (except the tutorial notebook, which is in scope for #158).

Major changes:

- Consistent spelling: lakeFS-spec, lakeFS, and fsspec
- Removed use cases page from docs, needs major overhaul
- Removed reference to constructor args in configuration user guide, since they can cause consistency issues