### PR TITLE
Remove `_strip_protocol` overload and usages

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -9,12 +9,11 @@ import urllib.error
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Literal, overload
+from typing import Any, Generator, Literal
 
 from fsspec import filesystem
 from fsspec.callbacks import Callback, NoOpCallback
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
-from fsspec.utils import stringify_path
 from lakefs_sdk import Configuration
 from lakefs_sdk.client import LakeFSClient
 from lakefs_sdk.exceptions import ApiException, NotFoundException
@@ -114,26 +113,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         self.client = LakeFSClient(configuration=configuration)
         self.create_branch_ok = create_branch_ok
         self.source_branch = source_branch
-
-    @classmethod
-    @overload
-    def _strip_protocol(cls, path: str | os.PathLike[str] | Path) -> str:
-        ...
-
-    @classmethod
-    @overload
-    def _strip_protocol(cls, path: list[str | os.PathLike[str] | Path]) -> list[str]:
-        ...
-
-    @classmethod
-    def _strip_protocol(cls, path):
-        """Copied verbatim from the base class, save for the slash rstrip."""
-        if isinstance(path, list):
-            return [cls._strip_protocol(p) for p in path]
-        spath = super()._strip_protocol(path)
-        if stringify_path(path).endswith("/"):
-            return spath + "/"
-        return spath
 
     @property
     def transaction(self):
@@ -249,8 +228,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         super().get_file(rpath=rpath, lpath=lpath, callback=callback, outfile=outfile, **kwargs)
 
     def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
-        path = self._strip_protocol(path)
-
         repository, ref, resource = parse(path)
         # first, try with `stat_object` in case of a file.
         # the condition below checks edge cases of resources that cannot be files.
@@ -291,7 +268,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         }
 
     def ls(self, path: str, detail: bool = True, **kwargs: Any) -> list:
-        path = self._strip_protocol(path)
         repository, ref, prefix = parse(path)
 
         # Try lookup in dircache unless explicitly disabled by `refresh=True` kwarg


### PR DESCRIPTION
Since we now account for a lakeFS URI scheme in the `parse` function (#169), we can drop the overload of `_strip_protocol` from the file system implementation.

Also removes its usages in our APIs, as is only logical if the `parse` function does the same job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/174)
<!-- Reviewable:end -->
