### PR TITLE
Remove `LakeFSFileSystem.scope` context manager

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -160,30 +160,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         except ApiException as e:
             raise translate_lakefs_error(e, message=message, set_cause=set_cause)
 
-    @contextmanager
-    def scope(
-        self,
-        create_branch_ok: bool | None = None,
-        source_branch: str | None = None,
-    ) -> EmptyYield:
-        """
-        A context manager yielding scope in which the lakeFS file system behavior
-        is changed from defaults.
-        """
-        curr_create_branch_ok, curr_source_branch = (
-            self.create_branch_ok,
-            self.source_branch,
-        )
-        try:
-            if create_branch_ok is not None:
-                self.create_branch_ok = create_branch_ok
-            if source_branch is not None:
-                self.source_branch = source_branch
-            yield
-        finally:
-            self.create_branch_ok = curr_create_branch_ok
-            self.source_branch = curr_source_branch
-
     def checksum(self, path: str) -> str | None:
         try:
             return self.info(path).get("checksum")

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -48,14 +48,13 @@ def test_merge_into_branch(
 
     with temporary_branch_context("merge-into-branch-test") as new_branch:
         source_ref = f"{repository}/{new_branch}/{random_file.name}"
-        with fs.scope(create_branch_ok=True):
-            fs.put(str(random_file), source_ref)
-            client_helpers.commit(
-                client=fs.client,
-                repository=repository,
-                branch=new_branch,
-                message="Commit new file",
-            )
+        fs.put(str(random_file), source_ref)
+        client_helpers.commit(
+            client=fs.client,
+            repository=repository,
+            branch=new_branch,
+            message="Commit new file",
+        )
 
         assert (
             len(
@@ -114,11 +113,12 @@ def test_revert(
 ) -> None:
     random_file = random_file_factory.make()
     source_ref = f"{repository}/{temp_branch}/{random_file.name}"
-    with fs.scope(create_branch_ok=True):
-        fs.put(str(random_file), source_ref)
-        client_helpers.commit(
-            client=fs.client, repository=repository, branch=temp_branch, message="Commit new file"
-        )
+
+    fs.put(str(random_file), source_ref)
+    client_helpers.commit(
+        client=fs.client, repository=repository, branch=temp_branch, message="Commit new file"
+    )
+
     assert (
         len(
             fs.client.refs_api.diff_refs(

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -48,26 +48,25 @@ def test_implicit_branch_creation(
     random_file = random_file_factory.make()
     lpath = str(random_file)
 
-    with fs.scope(create_branch_ok=True):
-        non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
-        rpath = f"{repository}/{non_existing_branch}/{random_file.name}"
-        try:
-            fs.put(lpath, rpath)
-            branches = [
-                r.id for r in fs.client.branches_api.list_branches(repository=repository).results
-            ]
-            assert non_existing_branch in branches
-        finally:
-            fs.client.branches_api.delete_branch(
-                repository=repository,
-                branch=non_existing_branch,
-            )
+    non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
+    rpath = f"{repository}/{non_existing_branch}/{random_file.name}"
+    try:
+        fs.put(lpath, rpath)
+        branches = [
+            r.id for r in fs.client.branches_api.list_branches(repository=repository).results
+        ]
+        assert non_existing_branch in branches
+    finally:
+        fs.client.branches_api.delete_branch(
+            repository=repository,
+            branch=non_existing_branch,
+        )
 
-    with fs.scope(create_branch_ok=False):
-        another_non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
-        rpath = f"{repository}/{another_non_existing_branch}/{random_file.name}"
-        with pytest.raises(FileNotFoundError):
-            fs.put(lpath, rpath)
+    fs.create_branch_ok = False
+    another_non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
+    rpath = f"{repository}/{another_non_existing_branch}/{random_file.name}"
+    with pytest.raises(FileNotFoundError):
+        fs.put(lpath, rpath)
 
 
 def test_put_client_caching(


### PR DESCRIPTION
This has realistically been superseded by the new `LakeFSTransaction.create_branch` functionality, since that provides the same API, in an easier interface, with the same context manager error handling capabilities.

However, the class-wide `create_branch_ok` and `source_branch` attributes are still useful to implicitly create branches without having to start transactions with a verbose leading `tx.create_branch`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/175)
<!-- Reviewable:end -->
