### PR TITLE
Docs: Render pre-release banner for `main`

### DIFF
--- a/.github/actions/mike-docs/action.yaml
+++ b/.github/actions/mike-docs/action.yaml
@@ -10,6 +10,9 @@ inputs:
     description: Whether to push the built documentation to the repository
     required: true
     default: "false"
+  pre_release:
+    description: Whether this version is a pre-release version (to render a notification banner)
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -21,7 +24,9 @@ runs:
       git config user.name "github-actions[bot]"
       git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     shell: bash
-  - run: |
+  - env:
+      DOCS_PRERELEASE: ${{ inputs.pre_release }}
+    run: |
       MIKE_OPTIONS=( "--update-aliases" )
       if [ "true" = "${{ inputs.push }}" ]; then
         MIKE_OPTIONS+=( "--push" )

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -66,4 +66,5 @@ jobs:
       uses: ./.github/actions/mike-docs
       with:
         version: development
+        pre_release: true  # include pre-release notification banner
         push: ${{ github.ref == 'refs/heads/main' }}  # build always, publish on 'main' only to prevent version clutter

--- a/docs/_styles/extra.css
+++ b/docs/_styles/extra.css
@@ -22,8 +22,15 @@ table {
 
 .celltag_remove_input,
 .celltag_remove_output,
+.celltag_hide_output,
 .celltag_Remove_input,
 .celltag_Remove_all_output,
 .celltag_Remove_single_output {
     display: none !important
+}
+
+/* Need to remove margin, since the template renders a div containing whitespace
+   when not enabling the banner, so using the :empty selector is not possible */
+.md-banner__inner {
+    margin: 0;
 }

--- a/docs/_theme_overrides/main.html
+++ b/docs/_theme_overrides/main.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block announce %}
+{% if config.extra.pre_release %}
+  <!-- Need to reapply margin from base template, which is removed in CSS (to fix empty banner) -->
+  <div style="margin: 0.6rem auto">
+    You are currently viewing <strong>development</strong> documentation. This may contain features that have not yet been released. For the most accurate information, please <strong><a href="{{ '../' ~ base_url }}">access the latest release</a></strong>.
+  </div>
+{% endif %}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ markdown_extensions:
 
 theme:
   name: "material"
+  custom_dir: docs/_theme_overrides
   logo: _images/aai-logo-cropped.png
   favicon: _images/aai-favicon.png
   font:
@@ -133,6 +134,7 @@ extra:
   copyright_link: https://appliedai-institute.de
   homepage: https://lakefs-spec.org
   generator: false
+  pre_release: !ENV [DOCS_PRERELEASE, false]
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
This PR adds a banner for the docs version built from `main` that lets the users know they are currently looking at a development release of the documentation.