### PR TITLE
Add HTTP409 check in `create_repository` for forward compatibility

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 
 from lakefs_sdk import BranchCreation
@@ -92,8 +93,10 @@ def create_repository(
         repository_creation = RepositoryCreation(name=name, storage_namespace=storage_namespace)
         return client.repositories_api.create_repository(repository_creation=repository_creation)
     except ApiException as e:
-        if e.status == 400 and "namespace already in use" in e.body and exist_ok:
-            return client.repositories_api.get_repository(name)
+        if exist_ok:
+            msg: str = json.loads(e.body)["message"]
+            if e.status == 400 and msg.endswith("namespace already in use") or e.status == 409:
+                return client.repositories_api.get_repository(name)
         raise e
 
 


### PR DESCRIPTION
With lakeFS 1.2.0. This breakage was observed in a local test against `treeverse/lakefs:latest`, which emits HTTP409 on an existing repo instead of HTTP400.

The code assumes that HTTP400 might happen for reasons other than an existing repository, but HTTP409 does not.

Since there is no easy way to obtain the version from the backend, we end up with an if-branch on the status code.

Fixes #173.