### PR TITLE
Adapt `create_tag` client helper to reflect tag immutability

### DIFF
--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -556,7 +556,7 @@
     "\n",
     "The above method for data versioning works great when you have experiment tracking tools to store and retrieve the commit SHA in automated pipelines. But it can be tedious to retrieve in manual prototyping. We can make selected versions of the dataset more accessible with semantic versioning by attaching a human-interpretable tag to a specific commit SHA.\n",
     "\n",
-    "Creating a tag is easiest when done inside a transaction, just like the files we already uploaded. To do this, simply call `tx.tag` on the transaction and supply the repository name, the commit SHA to tag, and the intended tag name."
+    "Creating a tag is easiest when done inside a transaction, just like the files we already uploaded. To do this, simply call `tx.tag` on the transaction and supply the repository name, the commit SHA to tag, and the intended tag name. The `exist_ok` flag handles creation errors, thrown if the tag does already exist. Since tags are immutable, the returned tag still points to the commit SHA it was previously assigned to. "
    ]
   },
   {
@@ -570,7 +570,7 @@
    "source": [
     "with fs.transaction as tx:\n",
     "    # the `tag` result is simply the tag name, in this case 'train-test-split-2010'.\n",
-    "    tag = tx.tag(repository=REPO_NAME, ref=fixed_commit_id, tag='train-test-split-2010')"
+    "    tag = tx.tag(repository=REPO_NAME, ref=fixed_commit_id, tag='train-test-split-2010', exist_ok=True)"
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -556,7 +556,7 @@
     "\n",
     "The above method for data versioning works great when you have experiment tracking tools to store and retrieve the commit SHA in automated pipelines. But it can be tedious to retrieve in manual prototyping. We can make selected versions of the dataset more accessible with semantic versioning by attaching a human-interpretable tag to a specific commit SHA.\n",
     "\n",
-    "Creating a tag is easiest when done inside a transaction, just like the files we already uploaded. To do this, simply call `tx.tag` on the transaction and supply the repository name, the commit SHA to tag, and the intended tag name. The `exist_ok` flag handles creation errors, thrown if the tag does already exist. Since tags are immutable, the returned tag still points to the commit SHA it was previously assigned to. "
+    "Creating a tag is easiest when done inside a transaction, just like the files we already uploaded. To do this, simply call `tx.tag` on the transaction and supply the repository name, the commit SHA to tag, and the intended tag name. Tags are immutable once created, so attempting to tag two different commits with the same name will result in an error."
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -570,7 +570,7 @@
    "source": [
     "with fs.transaction as tx:\n",
     "    # the `tag` result is simply the tag name, in this case 'train-test-split-2010'.\n",
-    "    tag = tx.tag(repository=REPO_NAME, ref=fixed_commit_id, tag='train-test-split-2010', exist_ok=True)"
+    "    tag = tx.tag(repository=REPO_NAME, ref=fixed_commit_id, tag='train-test-split-2010')"
    ]
   },
   {

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -193,6 +193,21 @@ def create_tag(
             logger.warning(f"The tag, '{tag}' already exists. It was not reassigned.")
             return client.tags_api.get_tag(repository=repository, tag=tag)
         raise e
+    
+def delete_tag(client: LakeFSClient, repository: str, tag:str) -> None:
+    """
+    Delete the specified tag from a repository.
+
+    Parameters
+    ----------
+    client : LakeFSClient
+        lakeFS client object.
+    repository : str
+        Name of the repository from which the tag will be deleted.
+    tag : str
+        Name of the tag to be deleted.
+    """
+    client.tags_api.delete_tag(repository=repository, tag=tag)
 
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -203,15 +203,12 @@ def delete_tag(client: LakeFSClient, repository: str, tag: str | Ref) -> None:
         lakeFS client object.
     repository : str
         Name of the repository from which the tag will be deleted.
-    tag : str
-        Name of the tag to be deleted.
+    tag : str | Ref
+        Tag to be deleted.
     """
-    if isinstance(tag, str):
-        client.tags_api.delete_tag(repository=repository, tag=tag)
-    elif isinstance(tag, Ref):
-        client.tags_api.delete_tag(repository=repository, tag=tag.id)
-    else:
-        raise ValueError(r"Type of tag must be str or Ref.")
+    if isinstance(tag, Ref):
+        tag = tag.id
+    client.tags_api.delete_tag(repository=repository, tag=tag)
 
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -153,7 +153,7 @@ def create_repository(
 
 
 def create_tag(
-    client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = True
+    client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = False
 ) -> Ref:
     """
     Create a new tag in the specified repository in the lakeFS file storage system.
@@ -190,6 +190,7 @@ def create_tag(
         return client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
     except ApiException as e:
         if e.status == 409 and exist_ok:
+            logger.warning(f"The tag, '{tag}' already exists. It was not reassigned.")
             return client.tags_api.get_tag(repository=repository, tag=tag)
         raise e
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -185,10 +185,11 @@ def create_tag(client: LakeFSClient, repository: str, ref: str | Commit, tag: st
     try:
         return client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
     except ApiException as e:
-        target_commit = rev_parse(client=client, repository=repository, ref=ref)
-        existing_tag = client.tags_api.get_tag(repository=repository, tag=tag)
-        if e.status == 409 and existing_tag.commit_id == target_commit.id:
-            return existing_tag
+        if e.status == 409:
+            target_commit = rev_parse(client=client, repository=repository, ref=ref)
+            existing_tag = client.tags_api.get_tag(repository=repository, tag=tag)
+            if existing_tag.commit_id == target_commit.id:
+                return existing_tag
         raise e
 
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -190,7 +190,7 @@ def create_tag(
         return client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
     except ApiException as e:
         if e.status == 409 and exist_ok:
-            logger.warning(f"The tag, '{tag}' already exists. It was not reassigned.")
+            logger.warning(f"tag {tag!r} already exists and is immutable")
             return client.tags_api.get_tag(repository=repository, tag=tag)
         raise e
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -193,7 +193,7 @@ def create_tag(client: LakeFSClient, repository: str, ref: str | Commit, tag: st
         raise e
 
 
-def delete_tag(client: LakeFSClient, repository: str, tag: str) -> None:
+def delete_tag(client: LakeFSClient, repository: str, tag: str | Ref ) -> None:
     """
     Delete the specified tag from a repository.
 
@@ -206,7 +206,12 @@ def delete_tag(client: LakeFSClient, repository: str, tag: str) -> None:
     tag : str
         Name of the tag to be deleted.
     """
-    client.tags_api.delete_tag(repository=repository, tag=tag)
+    if isinstance(tag, str):
+        client.tags_api.delete_tag(repository=repository, tag=tag)
+    elif isinstance(tag, Ref):
+        client.tags_api.delete_tag(repository=repository, tag=tag.id)
+    else:
+        raise ValueError(r"Type of tag must be str or Ref.")
 
 
 def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -193,7 +193,7 @@ def create_tag(client: LakeFSClient, repository: str, ref: str | Commit, tag: st
         raise e
 
 
-def delete_tag(client: LakeFSClient, repository: str, tag: str | Ref ) -> None:
+def delete_tag(client: LakeFSClient, repository: str, tag: str | Ref) -> None:
     """
     Delete the specified tag from a repository.
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -193,8 +193,9 @@ def create_tag(
             logger.warning(f"The tag, '{tag}' already exists. It was not reassigned.")
             return client.tags_api.get_tag(repository=repository, tag=tag)
         raise e
-    
-def delete_tag(client: LakeFSClient, repository: str, tag:str) -> None:
+
+
+def delete_tag(client: LakeFSClient, repository: str, tag: str) -> None:
     """
     Delete the specified tag from a repository.
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -152,9 +152,7 @@ def create_repository(
         raise e
 
 
-def create_tag(
-    client: LakeFSClient, repository: str, ref: str | Commit, tag: str, exist_ok: bool = False
-) -> Ref:
+def create_tag(client: LakeFSClient, repository: str, ref: str | Commit, tag: str) -> Ref:
     """
     Create a new tag in the specified repository in the lakeFS file storage system.
 
@@ -168,18 +166,16 @@ def create_tag(
         Commit SHA or Commit object of the commit to which the tag will point.
     tag: str
         Name of the tag to be created.
-    exist_ok: bool, optional
-        Ignore creation errors if the tag already exists. The tag is not reassigned.
 
     Raises
     ------
     ApiException
-        If a tag of the same name already exists and ``exist_ok=False``.
+        If a tag of the same name already exists and points to a different ref.
 
     Returns
     -------
     Ref
-        Ref object of the lakeFS SDK representing the newly created or existing tag.
+        Ref object of the lakeFS SDK representing the tag.
     """
 
     if isinstance(ref, Commit):
@@ -189,9 +185,10 @@ def create_tag(
     try:
         return client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
     except ApiException as e:
-        if e.status == 409 and exist_ok:
-            logger.warning(f"tag {tag!r} already exists and is immutable")
-            return client.tags_api.get_tag(repository=repository, tag=tag)
+        target_commit = rev_parse(client=client, repository=repository, ref=ref)
+        existing_tag = client.tags_api.get_tag(repository=repository, tag=tag)
+        if e.status == 409 and existing_tag.commit_id == target_commit.id:
+            return existing_tag
         raise e
 
 

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -144,16 +144,12 @@ class LakeFSTransaction(Transaction):
         self.files.append((op, p))
         return p
 
-    def tag(
-        self, repository: str, ref: str | Placeholder[Commit], tag: str, exist_ok: bool = True
-    ) -> str:
+    def tag(self, repository: str, ref: str | Placeholder[Commit], tag: str) -> str:
         """Create a tag referencing a commit in a repository."""
 
         def tag_op(client: LakeFSClient, **kwargs: Any) -> Ref:
             kwargs = unwrap_placeholders(kwargs)
             return create_tag(client, **kwargs)
 
-        self.files.append(
-            (partial(tag_op, repository=repository, ref=ref, tag=tag, exist_ok=exist_ok), tag)
-        )
+        self.files.append((partial(tag_op, repository=repository, ref=ref, tag=tag), tag))
         return tag

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -38,7 +38,7 @@ def test_create_tag(
             existing_tag = client_helpers.create_tag(
                 client=fs.client, repository=repository, ref=temp_branch, tag=tag, exist_ok=True
             )
-        assert re.search(".*already exists.*not reassigned.*", caplog.text)
+        assert re.search("tag .* already exists", caplog.text)
         assert new_tag == existing_tag
     finally:
         fs.client.tags_api.delete_tag(repository=repository, tag=tag)

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -57,10 +57,11 @@ def test_cannot_reassign_tag(
             repository=repository,
             temp_branch=temp_branch,
         )
-        with pytest.raises(ApiException):
+        with pytest.raises(ApiException) as e:
             client_helpers.create_tag(
                 client=fs.client, repository=repository, ref=temp_branch, tag=tagname
             )
+            assert e.status == 409
     finally:
         client_helpers.delete_tag(client=fs.client, repository=repository, tag=tagname)
 

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -10,28 +10,20 @@ from _pytest.logging import LogCaptureFixture
 
 import lakefs_spec.client_helpers as client_helpers
 from lakefs_spec import LakeFSFileSystem
-from tests.util import RandomFileFactory
+from tests.util import RandomFileFactory, add_and_commit_change_on_branch
 
 
-def test_create_tag(
-    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str, caplog: LogCaptureFixture
+def test_create_tag(random_file_factory: RandomFileFactory,fs: LakeFSFileSystem, repository: str, temp_branch: str, caplog: LogCaptureFixture
 ) -> None:
+    add_and_commit_change_on_branch(random_file_factory=random_file_factory, fs=fs, repository=repository, temp_branch=temp_branch)
     
-    random_file = random_file_factory.make()
-    lpath = str(random_file)
-    rpath = f"{repository}/{temp_branch}/{random_file.name}"
-
-    fs.put(lpath, rpath, precheck=False)
-
-    client_helpers.commit(
-        client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
-    )
-
     tag = f"Change_{uuid.uuid4()}"
     try:
         new_tag = client_helpers.create_tag(
             client=fs.client, repository=repository, ref=temp_branch, tag=tag
         )
+
+        
         assert tag in [commit.id for commit in client_helpers.list_tags(fs.client, repository)]
         with caplog.at_level(logging.WARNING):
             existing_tag = client_helpers.create_tag(

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -27,21 +27,21 @@ def test_create_tag(
         temp_branch=temp_branch,
     )
 
-    tag = f"Change_{uuid.uuid4()}"
+    tagname = f"Change_{uuid.uuid4()}"
     try:
-        new_tag = client_helpers.create_tag(
-            client=fs.client, repository=repository, ref=temp_branch, tag=tag
+        tag = client_helpers.create_tag(
+            client=fs.client, repository=repository, ref=temp_branch, tag=tagname
         )
 
-        assert tag in [commit.id for commit in client_helpers.list_tags(fs.client, repository)]
+        assert tag in client_helpers.list_tags(fs.client, repository)
         with caplog.at_level(logging.WARNING):
             existing_tag = client_helpers.create_tag(
-                client=fs.client, repository=repository, ref=temp_branch, tag=tag, exist_ok=True
+                client=fs.client, repository=repository, ref=temp_branch, tag=tagname, exist_ok=True
             )
         assert re.search("tag .* already exists", caplog.text)
-        assert new_tag == existing_tag
+        assert tag == existing_tag
     finally:
-        fs.client.tags_api.delete_tag(repository=repository, tag=tag)
+        fs.client.tags_api.delete_tag(repository=repository, tag=tagname)
 
 
 def test_delete_tag(
@@ -54,11 +54,11 @@ def test_delete_tag(
         temp_branch=temp_branch,
     )
 
-    tag = f"Change_{uuid.uuid4()}"
-    client_helpers.create_tag(client=fs.client, repository=repository, ref=temp_branch, tag=tag)
-    assert tag in [commit.id for commit in client_helpers.list_tags(fs.client, repository)]
-    client_helpers.delete_tag(client=fs.client, repository=repository, tag=tag)
-    assert tag not in [commit.id for commit in client_helpers.list_tags(fs.client, repository)]
+    tagname = f"Change_{uuid.uuid4()}"
+    tag = client_helpers.create_tag(client=fs.client, repository=repository, ref=temp_branch, tag=tagname)
+    assert tag in client_helpers.list_tags(fs.client, repository)
+    client_helpers.delete_tag(client=fs.client, repository=repository, tag=tagname)
+    assert tag not in client_helpers.list_tags(fs.client, repository)
 
 
 def test_merge_into_branch(

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -10,7 +10,7 @@ from _pytest.logging import LogCaptureFixture
 
 import lakefs_spec.client_helpers as client_helpers
 from lakefs_spec import LakeFSFileSystem
-from tests.util import RandomFileFactory, add_and_commit_change_on_branch
+from tests.util import RandomFileFactory, commit_random_file_on_branch
 
 
 def test_create_tag(
@@ -20,7 +20,7 @@ def test_create_tag(
     temp_branch: str,
     caplog: LogCaptureFixture,
 ) -> None:
-    add_and_commit_change_on_branch(
+    commit_random_file_on_branch(
         random_file_factory=random_file_factory,
         fs=fs,
         repository=repository,
@@ -47,7 +47,7 @@ def test_create_tag(
 def test_delete_tag(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
-    add_and_commit_change_on_branch(
+    commit_random_file_on_branch(
         random_file_factory=random_file_factory,
         fs=fs,
         repository=repository,

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -48,7 +48,7 @@ def test_cannot_reassign_tag(
 
     tagname = f"Change_{uuid.uuid4()}"
     try:
-        tag = client_helpers.create_tag(
+        client_helpers.create_tag(
             client=fs.client, repository=repository, ref=temp_branch, tag=tagname
         )
         commit_random_file_on_branch(
@@ -58,7 +58,7 @@ def test_cannot_reassign_tag(
             temp_branch=temp_branch,
         )
         with pytest.raises(ApiException):
-            tag = client_helpers.create_tag(
+            client_helpers.create_tag(
                 client=fs.client, repository=repository, ref=temp_branch, tag=tagname
             )
     finally:

--- a/tests/util.py
+++ b/tests/util.py
@@ -87,7 +87,7 @@ class RandomFileFactory:
         return random_file
 
 
-def add_and_commit_change_on_branch(
+def commit_random_file_on_branch(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
     random_file = random_file_factory.make()
@@ -99,4 +99,3 @@ def add_and_commit_change_on_branch(
     commit = client_helpers.commit(
         client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
     )
-    print("did commit", commit.id)

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from lakefs_sdk.client import LakeFSClient
+
 import lakefs_spec.client_helpers as client_helpers
 from lakefs_spec import LakeFSFileSystem
 
@@ -62,7 +63,6 @@ def with_counter(client: LakeFSClient) -> tuple[LakeFSClient, APICounter]:
     return client, counter
 
 
-
 class RandomFileFactory:
     def __init__(self, path: Union[str, Path]):
         path = Path(path)
@@ -86,7 +86,10 @@ class RandomFileFactory:
         random_file.write_text(random_str, encoding="utf-8")
         return random_file
 
-def add_and_commit_change_on_branch(random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str) -> None:
+
+def add_and_commit_change_on_branch(
+    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
     random_file = random_file_factory.make()
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/{random_file.name}"

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 from lakefs_sdk.client import LakeFSClient
+import lakefs_spec.client_helpers as client_helpers
+from lakefs_spec import LakeFSFileSystem
 
 
 class APICounter:
@@ -60,6 +62,7 @@ def with_counter(client: LakeFSClient) -> tuple[LakeFSClient, APICounter]:
     return client, counter
 
 
+
 class RandomFileFactory:
     def __init__(self, path: Union[str, Path]):
         path = Path(path)
@@ -82,3 +85,15 @@ class RandomFileFactory:
         random_str = "".join(random.choices(string.ascii_letters + string.digits, k=size))
         random_file.write_text(random_str, encoding="utf-8")
         return random_file
+
+def add_and_commit_change_on_branch(random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str) -> None:
+    random_file = random_file_factory.make()
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    fs.put(lpath, rpath, precheck=False)
+
+    commit = client_helpers.commit(
+        client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
+    )
+    print("did commit", commit.id)

--- a/tests/util.py
+++ b/tests/util.py
@@ -97,5 +97,8 @@ def commit_random_file_on_branch(
     fs.put(lpath, rpath, precheck=False)
 
     commit = client_helpers.commit(
-        client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
+        client=fs.client,
+        repository=repository,
+        branch=temp_branch,
+        message=f"Add file {random_file.name!r}",
     )


### PR DESCRIPTION
Tags are immutable as per design from lakeFS (stated on lakeFS GUI tag site, no rename_tag API and their [docs](https://docs.lakefs.io/understand/model.html#tags)). The client helper returns the tag that is still pointing to the previously assigned commit. 

Therefore, 
- [x] set the `exist_ok` default of the `create_tag` client helper to `False` such that allowing the tag to exist (for e.g. idempotency of a script) is a conscious choice.
- [x] Log a warning that the tag was not reassigned if the tag already existed, to inform the user. 
- [x] Adapt the tutorial notebook to these changes
- [x] Add `delete_tag`  client helper such that explicit renaming by deletion and recreation is possible via our API
- [x] Create `delete_tag` tests 

Closes https://github.com/aai-institute/lakefs-spec/issues/165

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/179)
<!-- Reviewable:end -->
