### PR TITLE
Add depagination helper

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -25,6 +25,8 @@ from lakefs_sdk.models import (
     TagCreation,
 )
 
+from lakefs_spec.util import depaginate
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -230,7 +232,7 @@ def list_tags(client: LakeFSClient, repository: str) -> list[Ref]:
     list[Ref]
         Ref objects of the tag in the repository.
     """
-    return client.tags_api.list_tags(repository=repository).results
+    return list(depaginate(client.tags_api.list_tags, repository))
 
 
 def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch: str) -> None:
@@ -314,16 +316,18 @@ def rev_parse(
         - If the provided ``ref`` does not match any revision in the specified repository.
     """
     if parent < 0:
-        raise ValueError(f"Parent cannot be negative, got {parent}")
+        raise ValueError("Parent number cannot be negative")
     try:
         if isinstance(ref, Commit):
             ref = ref.id
-        revisions = client.refs_api.log_commits(
-            repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
-        ).results
+        revisions = list(
+            depaginate(
+                client.refs_api.log_commits, repository, ref, limit=True, amount=2 * (parent + 1)
+            )
+        )
         if len(revisions) <= parent:
             raise ValueError(
-                f"cannot fetch revision {ref}~{parent}: "
+                f"unable to fetch revision {ref}~{parent}: "
                 f"ref {ref!r} only has {len(revisions)} parents"
             )
         return revisions[parent]

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Literal
+from typing import Any, Generator, Literal, cast
 
 from fsspec import filesystem
 from fsspec.callbacks import Callback, NoOpCallback
@@ -17,7 +17,7 @@ from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from lakefs_sdk import Configuration
 from lakefs_sdk.client import LakeFSClient
 from lakefs_sdk.exceptions import ApiException, NotFoundException
-from lakefs_sdk.models import ObjectCopyCreation, StagingMetadata
+from lakefs_sdk.models import ObjectCopyCreation, ObjectStats, StagingMetadata
 
 from lakefs_spec.client_helpers import create_branch
 from lakefs_spec.config import LakectlConfig
@@ -271,7 +271,8 @@ class LakeFSFileSystem(AbstractFileSystem):
         info = []
         # stat infos are either the path only (`detail=False`) or a dict full of metadata
         with self.wrapped_api_call():
-            for obj in depaginate(self.client.objects_api.list_objects, repository, ref, **kwargs):
+            objects = depaginate(self.client.objects_api.list_objects, repository, ref, **kwargs)
+            for obj in cast(list[ObjectStats], objects):
                 info.append(
                     {
                         "checksum": obj.checksum,

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Literal, cast
+from typing import Any, Generator, Iterable, Literal, cast
 
 from fsspec import filesystem
 from fsspec.callbacks import Callback, NoOpCallback
@@ -272,7 +272,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         # stat infos are either the path only (`detail=False`) or a dict full of metadata
         with self.wrapped_api_call():
             objects = depaginate(self.client.objects_api.list_objects, repository, ref, **kwargs)
-            for obj in cast(list[ObjectStats], objects):
+            for obj in cast(Iterable[ObjectStats], objects):
                 info.append(
                     {
                         "checksum": obj.checksum,

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,25 +1,22 @@
 import hashlib
 import re
-from typing import Callable, Generator, ParamSpec, Protocol, TypeVar
+from typing import Any, Callable, Generator, Protocol
 
+from lakefs_sdk import Pagination
 from lakefs_sdk import __version__ as __lakefs_sdk_version__
-from lakefs_sdk.models import Pagination
 
 lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
 del __lakefs_sdk_version__
 
-T = TypeVar("T")
-P = ParamSpec("P")
 
-
-class PaginatedApiResponse(Protocol[T]):
+class PaginatedApiResponse(Protocol):
     pagination: Pagination
-    results: list[T]
+    results: list
 
 
 def depaginate(
-    api: Callable[P, PaginatedApiResponse[T]], *args: P.args, **kwargs: P.kwargs
-) -> Generator[T, None, None]:
+    api: Callable[..., PaginatedApiResponse], *args: Any, **kwargs: Any
+) -> Generator[Any, None, None]:
     """Send a number of lakeFS API response documents to a generator."""
     while True:
         resp = api(*args, **kwargs)

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -230,7 +230,7 @@ def test_rev_parse_error_on_parent_does_not_exist(
     non_existent_parent = n_commits + 1
     with pytest.raises(
         ValueError,
-        match=f"cannot fetch revision {temp_branch}~{non_existent_parent}",
+        match=f"unable to fetch revision {temp_branch}~{non_existent_parent}",
     ):
         client_helpers.rev_parse(
             client=fs.client, repository=repository, ref=temp_branch, parent=non_existent_parent


### PR DESCRIPTION
This is basically the lakeFS SDK example with some typing to improve the expected inputs and outputs.

I'm pretty sure the generic typing does not work, since mypy does not make the connection from a pydantic response model (say, `RefList`) to the result type (in this case, `list[Ref]`).

My idea was a "C++ template specialization" kind of approach, forwarding `RefList = PaginatedApiResponse[Ref]`, but it seems like that's not directly possible in the current typing.

This also likely needs some logic to accommodate Python 3.9 with the `ParamSpec` usage and so on.

Closes #178.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/180)
<!-- Reviewable:end -->
