### PR TITLE
Create API docstrings for the `LakeFSFileSystem` and `LakeFSFile`

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -1,3 +1,8 @@
+"""
+Contains the core interface definitions for file system interaction with lakeFS from Python,
+namely the ``LakeFSFileSystem`` and ``LakeFSFile`` classes.
+"""
+
 from __future__ import annotations
 
 import io
@@ -12,7 +17,7 @@ from pathlib import Path
 from typing import Any, Generator, Iterable, Literal, cast
 
 from fsspec import filesystem
-from fsspec.callbacks import Callback, NoOpCallback
+from fsspec.callbacks import _DEFAULT_CALLBACK, Callback
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from fsspec.utils import stringify_path
 from lakefs_sdk import Configuration
@@ -26,8 +31,6 @@ from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.transaction import LakeFSTransaction
 from lakefs_spec.util import depaginate, md5_checksum, parse
 
-_DEFAULT_CALLBACK = NoOpCallback()
-
 logger = logging.getLogger(__name__)
 
 EmptyYield = Generator[None, None, None]
@@ -37,8 +40,7 @@ class LakeFSFileSystem(AbstractFileSystem):
     """
     lakeFS file system implementation.
 
-    The client is immutable in this implementation, so different users need different
-    file systems.
+    The client is immutable in this implementation, so different users need different file systems.
     """
 
     protocol = "lakefs"
@@ -60,7 +62,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         **storage_options: Any,
     ):
         """
-        The lakeFS file system constructor.
+        Construct a lakeFS file system.
 
         Parameters
         ----------
@@ -117,10 +119,11 @@ class LakeFSFileSystem(AbstractFileSystem):
 
     @property
     def transaction(self):
-        """A context within which files are committed together upon exit
+        """
+        A context manager within which file uploads and versioning operations are deferred to a
+        queue, and carried during __exit__.
 
-        Requires the file class to implement `.commit()` and `.discard()`
-        for the normal and exception cases.
+        Requires the file class to implement `.commit()` and `.discard()` for the normal and exception cases.
         """
         self._transaction: LakeFSTransaction | None
         if self._transaction is None:
@@ -128,19 +131,48 @@ class LakeFSFileSystem(AbstractFileSystem):
         return self._transaction
 
     def start_transaction(self):
-        """Begin write transaction for deferring files, non-context version"""
+        """
+        Prepare a lakeFS file system transaction without entering the transaction context yet.
+        """
         self._intrans = True
         self._transaction = LakeFSTransaction(self)
         return self.transaction
 
     @contextmanager
     def wrapped_api_call(self, message: str | None = None, set_cause: bool = True) -> EmptyYield:
+        """
+        A context manager to wrap lakeFS API calls, translating API errors to Python-native OS errors if they occur.
+
+        Meant for internal use.
+
+        Parameters
+        ----------
+        message: str | None
+            A custom error message to emit instead of parsing the API error response.
+        set_cause: bool
+            Whether to include the original lakeFS API error in the resulting traceback.
+        """
         try:
             yield
         except ApiException as e:
             raise translate_lakefs_error(e, message=message, set_cause=set_cause)
 
     def checksum(self, path: str | os.PathLike[str]) -> str | None:
+        """
+        Get a remote lakeFS file object's checksum.
+
+        This is usually its MD5 hash, unless another hash function was used on upload.
+
+        Parameters
+        ----------
+        path: str
+            The remote path to look up the lakeFS checksum for. Must point to a single file object.
+
+        Returns
+        -------
+        str | None
+            The remote file's checksum, or None (if ``path`` points to a directory or does not exist).
+        """
         path = stringify_path(path)
         try:
             return self.info(path).get("checksum")
@@ -148,6 +180,28 @@ class LakeFSFileSystem(AbstractFileSystem):
             return None
 
     def exists(self, path: str | os.PathLike[str], **kwargs: Any) -> bool:
+        """
+        Check existence of a remote path in lakeFS.
+
+        Input paths can be either files or directories.
+
+        Parameters
+        ----------
+        path: str
+            The remote path whose existence to check. Must be a fully qualified lakeFS URI.
+        kwargs: Any
+            Additional keyword arguments to pass to ``LakeFSClient.objects_api.head_object()``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the requested path exists, ``False`` if it does not.
+
+        Raises
+        ------
+        PermissionError
+            If the user does not have sufficient permissions to query object existence.
+        """
         path = stringify_path(path)
         repository, ref, resource = parse(path)
 
@@ -164,6 +218,18 @@ class LakeFSFileSystem(AbstractFileSystem):
     def cp_file(
         self, path1: str | os.PathLike[str], path2: str | os.PathLike[str], **kwargs: Any
     ) -> None:
+        """
+        Copy a single file from one remote location to another in lakeFS.
+
+        Parameters
+        ----------
+        path1: str
+            The remote file location to be copied.
+        path2: str
+            The target location to which to copy the file.
+        kwargs: Any
+            Additional keyword arguments to pass to ``LakeFSClient.objects_api.copy_object()``.
+        """
         path1 = stringify_path(path1)
         path2 = stringify_path(path2)
         if path1 == path2:
@@ -197,6 +263,24 @@ class LakeFSFileSystem(AbstractFileSystem):
         precheck: bool = True,
         **kwargs: Any,
     ) -> None:
+        """
+        Download a single file from a remote lakeFS server to local storage.
+
+        Parameters
+        ----------
+        rpath: str
+            The remote path to download to local storage. Must be a fully qualified lakeFS URI, and point to a single file.
+        lpath: str
+            The local path on disk to save the downloaded file to.
+        callback: fsspec.callbacks.Callback
+            An fsspec callback to use during the operation. Can be used to report download progress.
+        outfile: File-like object
+            A file-like object to save the downloaded content to. Can be used in place of ``lpath``.
+        precheck: bool
+            Check if ``lpath`` already exists and compare its checksum with that of ``rpath``, skipping the download if they match.
+        kwargs: Any
+            Additional keyword arguments passed to ``AbstractFileSystem.open()``.
+        """
         rpath = stringify_path(rpath)
         lpath = stringify_path(lpath)
         lp = Path(lpath)
@@ -213,6 +297,22 @@ class LakeFSFileSystem(AbstractFileSystem):
         super().get_file(rpath=rpath, lpath=lpath, callback=callback, outfile=outfile, **kwargs)
 
     def info(self, path: str | os.PathLike[str], **kwargs: Any) -> dict[str, Any]:
+        """
+        Query a remote lakeFS object's metadata.
+
+        Parameters
+        ----------
+        path: str
+            The object for which to obtain metadata. Must be a fully qualified lakeFS URI, can either point to a file or a directory.
+        kwargs: Any
+            Additional keyword arguments to pass to either ``LakeFSClient.objects_api.stat_object()``
+            (if ``path`` points to a file) or ``LakeFSClient.objects_api.list_objects()`` (if ``path`` points to a directory).
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing metadata on the object, including its full remote path and object type (file or directory).
+        """
         path = stringify_path(path)
         repository, ref, resource = parse(path)
         # first, try with `stat_object` in case of a file.
@@ -254,6 +354,24 @@ class LakeFSFileSystem(AbstractFileSystem):
         }
 
     def ls(self, path: str | os.PathLike[str], detail: bool = True, **kwargs: Any) -> list:
+        """
+        List all available objects under a given path in lakeFS.
+
+        Parameters
+        ----------
+        path: str
+            The path under which to list objects. Must be a fully qualified lakeFS URI.
+            Can also point to a file, in which case the file's metadata will be returned.
+        detail: bool
+            Whether to obtain all metadata on the requested objects or just their names.
+        kwargs: Any
+            Additional keyword arguments to pass to ``LakeFSClient.objects_api.list_objects()``.
+
+        Returns
+        -------
+        list[str | dict[str, Any]]
+            A list of all objects' metadata under the given remote path if ``detail == True``, or alternatively only their names if ``detail == False``.
+        """
         path = stringify_path(path)
         repository, ref, prefix = parse(path)
 
@@ -322,6 +440,32 @@ class LakeFSFileSystem(AbstractFileSystem):
         cache_options: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> LakeFSFile:
+        """
+        Dispatch a lakeFS file (local buffer on disk) for the given remote path for up- or downloads depending on ``mode``.
+
+        Internal only, called by ``AbstractFileSystem.open()``.
+
+        Parameters
+        ----------
+        path: str
+            The remote path for which to open a local ``LakeFSFile``. Must be a fully qualified lakeFS URI.
+        mode: Literal["rb", "wb"]
+            The file mode indicating its purpose. Use ``rb`` for downloads from lakeFS, ``wb`` for uploads to lakeFS.
+        block_size: int | None
+            The file block size to read at a time. If not set, falls back to fsspec's default blocksize of 5 MB.
+        autocommit: bool
+            Whether to write the file buffer automatically on file closing in write mode.
+        cache_options: dict[str, str] | None
+            Additional caching options to pass to the ``AbstractBufferedFile`` superclass.
+        kwargs: Any
+            Additional keyword arguments to pass to ``LakeFSClient.objects_api.get_object()`` on download (``mode == 'rb'),
+            or ``LakeFSClient.objects_api.put_object()`` on upload (``mode == 'wb').
+
+        Returns
+        -------
+        LakeFSFile
+            A local file-like object ready to hold data to be received from / sent to a lakeFS server.
+        """
         if mode not in {"rb", "wb"}:
             raise NotImplementedError(f"unsupported mode {mode!r}")
 
@@ -343,6 +487,27 @@ class LakeFSFileSystem(AbstractFileSystem):
         presign: bool = False,
         storage_options: dict[str, Any] | None = None,
     ) -> None:
+        """
+        Upload a file to lakeFS by directly putting it into its underlying block storage, thereby reducing the request load
+        on the lakeFS server.
+
+        Requires the corresponding fsspec implementation for the block storage type used by your lakeFS server deployment.
+
+        Supported block storage types are S3 (needs ``s3fs``), GCS (needs ``gcsfs``), and Azure Blob Storage (needs ``adlfs``).
+
+        Parameters
+        ----------
+        lpath: str
+            The local path to upload to the lakeFS block storage.
+        rpath: str
+            The remote target path to upload the local file to. Must be a fully qualified lakeFS URI.
+        callback: fsspec.callbacks.Callback
+            An fsspec callback to use during the operation. Can be used to report download progress.
+        presign: bool
+            Whether to use pre-signed URLs to upload the object via HTTP(S) using ``urllib.request``.
+        storage_options: dict[str, Any] | None
+            Additional file system configuration options to pass to the block storage file system.
+        """
         rpath = stringify_path(rpath)
         lpath = stringify_path(lpath)
         repository, branch, resource = parse(rpath)
@@ -410,6 +575,29 @@ class LakeFSFileSystem(AbstractFileSystem):
         storage_options: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Upload a local file to a remote location on a lakeFS server.
+
+        Parameters
+        ----------
+        lpath: str
+            The local path on disk to upload to the lakeFS server.
+        rpath: str
+            The remote target path to upload the local file to. Must be a fully qualified lakeFS URI.
+        callback: fsspec.callbacks.Callback
+            An fsspec callback to use during the operation. Can be used to report download progress.
+        precheck: bool
+            Check if ``lpath`` already exists and compare its checksum with that of ``rpath``, skipping the download if they match.
+        use_blockstore: bool
+            Optionally upload the file directly to the underlying block storage, thereby bypassing the lakeFS server and saving a
+            file transfer. Preferable for uploads of large files.
+        presign: bool
+            Whether to use pre-signed URLs to upload the object if ``use_blockstore == True``.
+        storage_options: dict[str, Any] | None
+            Additional file system configuration options to pass to the block storage file system if ``use_blockstore == True``.
+        kwargs: Any
+            Additional keyword arguments to pass to ``AbstractFileSystem.open()``.
+        """
         lpath = stringify_path(lpath)
         rpath = stringify_path(rpath)
         if precheck and Path(lpath).is_file():
@@ -434,6 +622,16 @@ class LakeFSFileSystem(AbstractFileSystem):
             super().put_file(lpath=lpath, rpath=rpath, callback=callback, **kwargs)
 
     def rm_file(self, path: str) -> None:
+        """
+        Stage a remote file for removal on a lakeFS server.
+
+        After executing this function, the requested file will not actually be removed from the requested branch until another commit is created.
+
+        Parameters
+        ----------
+        path: str
+            The remote file to delete. Must be a fully qualified lakeFS URI.
+        """
         repository, branch, resource = parse(path)
 
         with self.wrapped_api_call():
@@ -457,6 +655,31 @@ class LakeFSFile(AbstractBufferedFile):
         size: int | None = None,
         **kwargs: Any,
     ):
+        """
+        Initialize a lakeFS file (local buffer on disk) for the given remote path for up- or downloads depending on ``mode``.
+
+        Parameters
+        ----------
+        fs: LakeFSFileSystem
+            The lakeFS file system associated to this file.
+        path: str
+            The remote path to either up- or download depending on ``mode``. Must be a fully qualified lakeFS URI.
+        mode: Literal["rb", "wb"]
+            The file mode indicating its purpose. Use ``rb`` for downloads from lakeFS, ``wb`` for uploads to lakeFS.
+        block_size: int | str
+            The file block size to read at a time. If not set, falls back to fsspec's default blocksize of 5 MB.
+        autocommit: bool
+            Whether to write the file buffer automatically to lakeFS on file closing in write mode.
+        cache_type: str
+            Cache type to use in the ``AbstractBufferedFile`` superclass.
+        cache_options: dict[str, Any] | None
+            Additional caching options to pass to the ``AbstractBufferedFile`` superclass.
+        size: int | None
+            If given and ``mode == 'rb'``, this will be used as the file size (in bytes).
+        kwargs: Any
+            Additional keyword arguments to pass to ``LakeFSClient.objects_api.get_object()`` on download (``mode == 'rb'),
+            or ``LakeFSClient.objects_api.put_object()`` on upload (``mode == 'wb').
+        """
         path = stringify_path(path)
         super().__init__(
             fs,
@@ -476,13 +699,30 @@ class LakeFSFile(AbstractBufferedFile):
             create_branch(self.fs.client, repository, branch, self.fs.source_branch)
 
     def _upload_chunk(self, final: bool = False) -> bool:
-        """Commits the file on final chunk via single-shot upload, no-op otherwise."""
+        """
+        Commits the file on final chunk via single-shot upload, no-op otherwise.
+
+        Parameters
+        ----------
+        final: bool
+            Proceed with uploading the file if ``self.autocommit == True``.
+
+        Returns
+        -------
+        bool
+            If the file buffer needs more data to be written before initiating the upload.
+
+        """
         if final and self.autocommit:
             self.commit()
         return not final
 
     def commit(self):
-        """Commit the file via single-shot upload."""
+        """
+        Upload the file to lakeFS in single-shot mode.
+
+        Results in an unbuffered upload, and a memory allocation in the magnitude of the file size on the caller's host machine.
+        """
         repository, branch, resource = parse(self.path)
 
         with self.fs.wrapped_api_call():
@@ -493,11 +733,13 @@ class LakeFSFile(AbstractBufferedFile):
                 branch=branch,
                 path=resource,
                 content=self.buffer.read(),
+                **self.kwargs,
             )
 
         self.buffer = io.BytesIO()
 
     def discard(self):
+        """Discard the file's current buffer."""
         self.buffer = io.BytesIO()  # discards the data, but in a type-safe way.
 
     def flush(self, force: bool = False) -> None:
@@ -543,8 +785,25 @@ class LakeFSFile(AbstractBufferedFile):
             self.offset += self.buffer.seek(0, 2)
 
     def _fetch_range(self, start: int, end: int) -> bytes:
+        """
+        Fetch a byte range of the ``LakeFSFile``'s target remote path.
+
+        The byte range is right-exclusive, meaning that the amount of transferred bytes equals end - start.
+
+        Parameters
+        ----------
+        start: int
+            Start of the byte range, inclusive.
+        end: int
+            End of the byte range, exclusive. Must be greater than ``start``
+
+        Returns
+        -------
+        bytearray
+            A byte array holding the downloaded data from lakeFS.
+        """
         repository, ref, resource = parse(self.path)
         with self.fs.wrapped_api_call():
             return self.fs.client.objects_api.get_object(
-                repository, ref, resource, range=f"bytes={start}-{end - 1}"
+                repository, ref, resource, range=f"bytes={start}-{end - 1}", **self.kwargs
             )


### PR DESCRIPTION
Annotates all overloaded methods, both public and private, on the `LakeFSFileSystem` and `LakeFSFile` classes.

Some hints about input values (e.g. `rpath`s having to be fully qualified lakeFS URIs) were duplicated across all APIs, since a user might use only a subset of APIs.

Also forwards the `LakeFSFile`'s keyword arguments supplied on construction to the respective `objects_api.{get,put}_object` calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/181)
<!-- Reviewable:end -->
