### PR TITLE
Add API docs for all remaining smaller modules

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -51,8 +51,8 @@ def commit(
         Branch name.
     message: str
         Commit message.
-    metadata: dict[str, str] | None, optional
-        Additional metadata for the commit. Defaults to None.
+    metadata: dict[str, str] | None
+        Additional metadata for the commit.
 
     Returns
     -------
@@ -77,7 +77,7 @@ def create_branch(
     client: LakeFSClient, repository: str, name: str, source_branch: str, exist_ok: bool = True
 ) -> str:
     """
-    Create a branch in a lakeFS repository.
+    Create a branch ``name`` in a lakeFS repository.
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ def create_repository(
         Name of the repository to be created. This must be unique within the lakeFS instance.
     storage_namespace: str
         Storage namespace where the repository data will reside, typically corresponding to a bucket in object storage (e.g., S3 bucket) or a local namespace (e.g. local://<repo_name>).
-    exist_ok: bool, optional
+    exist_ok: bool
         Ignore creation errors if the repository already exists.
 
     Returns
@@ -275,7 +275,8 @@ def revert(client: LakeFSClient, repository: str, branch: str, parent_number: in
     branch: str
         Branch on which the commit should be reverted.
     parent_number: int, optional
-        If there are multiple parents to a commit, specify to which parent the commit should be reverted. Index starts at 1.
+        If there are multiple parents to a commit, specify to which parent the commit should be reverted.
+        ``parent_number = 1`` (the default)  refers to the first parent commit of the current ``branch`` tip.
     """
     revert_creation = RevertCreation(ref=branch, parent_number=parent_number)
     client.branches_api.revert_branch(
@@ -300,8 +301,9 @@ def rev_parse(
         Name of the repository where the commit will be searched.
     ref: str | Commit
         Commit SHA or Commit object (with SHA stored in its ``id`` attribute) to resolve.
-    parent: int, optional
-        Number of parent commits to go back from the specified ``ref``. Defaults to 0, which means no parent traversal.
+    parent: int
+        Optionally parse a parent of ``ref`` instead of ``ref`` itself as indicated by the number.
+        Must be non-negative. ``parent = 0`` (the default)  refers to ``ref`` itself.
 
     Returns
     -------

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,3 +1,7 @@
+"""
+A lightweight, immutable object holding ``lakectl`` configuration relevant for authentication in the lakeFS file system.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -7,12 +11,33 @@ import yaml
 
 
 class LakectlConfig(NamedTuple):
+    """
+    Holds configuration values necessary for authentication with a lakeFS server from Python.
+    """
+
     host: str | None = None
+    """URL of the lakeFS host, http(s) prefix is optional."""
     username: str | None = None
+    """The access key ID to use in authentication with lakeFS."""
     password: str | None = None
+    """The secret access key to use in authentication with lakeFS."""
 
     @classmethod
     def read(cls, path: str | Path) -> "LakectlConfig":
+        """
+        Read in a lakectl YAML configuration file and parse out relevant authentication parameters.
+
+        Parameters
+        ----------
+        path: str
+            Path to the YAML configuration file.
+
+        Returns
+        -------
+        LakectlConfig
+            The immutable loaded configuration. All missing relevant values are filled with ``None`` placeholders.
+
+        """
         if not Path(path).exists():
             raise FileNotFoundError(path)
 

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,5 +1,5 @@
 """
-A lightweight, immutable object holding ``lakectl`` configuration relevant for authentication in the lakeFS file system.
+Functionality for working with ``lakectl`` configuration files useable for authentication in the lakeFS file system.
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ class LakectlConfig(NamedTuple):
         Returns
         -------
         LakectlConfig
-            The immutable loaded configuration. All missing relevant values are filled with ``None`` placeholders.
+            The immutable loaded configuration. Missing values are filled with ``None`` placeholders.
 
         """
         if not Path(path).exists():

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -1,7 +1,7 @@
 """
-Contains the error translation facilities to map lakeFS API errors to Python-native OS errors in the lakeFS file system.
+Error translation facilities to map lakeFS API errors to Python-native OS errors in the lakeFS file system.
 
-This is important to honor the fsspec API contract, which allows users to only deal with Python builtin exceptions to
+This is important to honor the fsspec API contract, where users only need to expect builtin Python exceptions to
 avoid complicated error handling setups.
 """
 
@@ -39,11 +39,10 @@ def translate_lakefs_error(
     error : lakefs_client.ApiException
         The exception returned by the lakeFS API.
     message : str
-        An error message to use for the returned exception. If not given, the
-        error message returned by the lakeFS server is used instead.
+        An error message to use for the returned exception.
+         If not given, the error message returned by the lakeFS server is used instead.
     set_cause : bool
-        Whether to set the ``__cause__`` attribute to the previous exception if the
-        exception is translated.
+        Whether to set the ``__cause__`` attribute to the previous exception if the exception is translated.
     *args:
         Additional arguments to pass to the exception constructor, after the
         error message. Useful for passing the filename arguments to ``IOError``.

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -1,3 +1,10 @@
+"""
+Contains the error translation facilities to map lakeFS API errors to Python-native OS errors in the lakeFS file system.
+
+This is important to honor the fsspec API contract, which allows users to only deal with Python builtin exceptions to
+avoid complicated error handling setups.
+"""
+
 from __future__ import annotations
 
 import errno
@@ -20,7 +27,11 @@ def translate_lakefs_error(
     set_cause: bool = True,
     *args: Any,
 ) -> OSError:
-    """Convert a lakeFS client ApiException into a Python exception.
+    """
+    Convert a lakeFS API exception to a Python builtin exception.
+
+    For some subclasses of ``lakefs_sdk.ApiException``, a direct Python builtin equivalent exists.
+    In these cases, the suitable equivalent is returned. All other classes are converted to a standard ``IOError``.
 
     Parameters
     ----------
@@ -40,8 +51,7 @@ def translate_lakefs_error(
     Returns
     -------
     OSError
-        An instantiated exception ready to be thrown. If the error code isn't
-        recognized, an ``IOError`` with the original error message is returned.
+        A builtin Python exception ready to be thrown.
     """
     status, reason, body = error.status, error.reason, error.body
 

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -1,5 +1,5 @@
 """
-Contains the ``LakeFSTransaction``, a subclass of ``fsspec.transaction.Transaction`` capable of conducting versioning operations between file uploads.
+Functionality for extended lakeFS transactions to conduct versioning operations between file uploads.
 """
 
 from __future__ import annotations
@@ -52,12 +52,16 @@ def unwrap_placeholders(kwargs: dict[str, Any]) -> dict[str, Any]:
 
 
 class LakeFSTransaction(Transaction):
-    """A lakeFS transaction model capable of versioning operations in between file uploads."""
+    """
+    A lakeFS transaction model capable of versioning operations in between file uploads.
+
+    Parameters
+    ----------
+    fs: LakeFSFileSystem
+        The lakeFS file system associated with the transaction.
+    """
 
     def __init__(self, fs: "LakeFSFileSystem"):
-        """
-        Initialize a lakeFS transaction. The base class' ``file`` stack can also contain versioning operations.
-        """
         super().__init__(fs=fs)
         self.fs: "LakeFSFileSystem"
         self.files: deque[AbstractBufferedFile | VersioningOpTuple] = deque(self.files)
@@ -105,7 +109,7 @@ class LakeFSTransaction(Transaction):
         2. Conducting versioning operations using the file system's client.
 
         No operations happen and all files are discarded if ``commit == False``,
-        which is the case e.g. if an exception happens in the context manager.
+        which is the case, e.g., if an exception happens in the context manager.
 
         Parameters
         ----------
@@ -137,7 +141,7 @@ class LakeFSTransaction(Transaction):
         self, repository: str, name: str, source_branch: str, exist_ok: bool = True
     ) -> str:
         """
-        Create a branch with the name ``name`` in a repository, branching off ``source_branch``.
+        Create a branch ``name`` in a repository, branching off ``source_branch``.
 
         Parameters
         ----------
@@ -194,6 +198,7 @@ class LakeFSTransaction(Transaction):
             Branch on which the commit should be reverted.
         parent_number: int
             If there are multiple parents to a commit, specify to which parent the commit should be reverted.
+            ``parent_number = 1`` (the default)  refers to the first parent commit of the current ``branch`` tip.
         """
 
         op = partial(revert, repository=repository, branch=branch, parent_number=parent_number)
@@ -214,7 +219,7 @@ class LakeFSTransaction(Transaction):
             Commit SHA or commit placeholder object to resolve.
         parent: int
             Optionally parse a parent of ``ref`` instead of ``ref`` itself as indicated by the number.
-             Must be non-negative. ``parent = 0`` (the default) means the actual given ``ref``.
+            Must be non-negative. ``parent = 0`` (the default)  refers to ``ref`` itself.
 
         Returns
         -------

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,5 +1,5 @@
 """
-Contains a few useful utilities for handling lakeFS URIs and results of lakeFS API calls.
+Useful utilities for handling lakeFS URIs and results of lakeFS API calls.
 """
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ def depaginate(
     api: Callable[..., PaginatedApiResponse], *args: Any, **kwargs: Any
 ) -> Generator[Any, None, None]:
     """
-    Send a number of received lakeFS API response documents to a generator.
+    Unwrap the responses from a paginated lakeFS API method into a generator.
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ def depaginate(
 
     Yields
     ------
-    pydantic.BaseModel
+    Any
         The obtained API result objects.
     """
     while True:
@@ -54,7 +54,7 @@ def md5_checksum(lpath: str | os.PathLike[str], blocksize: int = 2**22) -> str:
 
     Parameters
     ----------
-    lpath: str
+    lpath: str | os.PathLike[str]
         The local path whose MD5 hash to calculate. Must be a file.
     blocksize: int
         Block size (in bytes) to use while reading in the file.
@@ -81,7 +81,7 @@ def parse(path: str) -> tuple[str, str, str]:
     ----------
     path: str
         String path, needs to conform to the lakeFS URI format described above.
-        The ``<resource>`` part can be the empty string; the leading ``lakefs://`` scheme can be omitted.
+        The ``<resource>`` part can be the empty string; the leading ``lakefs://`` scheme may be omitted.
 
     Returns
     -------


### PR DESCRIPTION
Contains API and module docstrings for the `lakefs_spec.config`, `lakefs_spec.errors`, `lakefs_spec.transaction`, and `lakefs_spec.util` modules.

The versioning method docs on the `LakeFSTransaction` were mostly copied over from the respective client helpers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aai-institute/lakefs-spec/184)
<!-- Reviewable:end -->
