### PR TITLE
Record test coverage on `fsspec` package [ENG-196]

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -57,7 +57,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip pytest pytest-cov pyyaml
         python -m pip install -e .
-        pytest -s --cov=src --cov=fsspec --cov-branch
+        pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -57,7 +57,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip pytest pytest-cov pyyaml
         python -m pip install -e .
-        pytest -s --cov=src --cov-branch
+        pytest -s --cov=src --cov=fsspec --cov-branch
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:


### PR DESCRIPTION
In order to gauge the effectiveness of our test suite, we should not
only measure coverage on our own code, but rather on the abstract
base classes for the file system and file implementations as well.

This commit adds the necessary parameters to the `pytest` invocation
in CI, which then ends up in the CodeCov reports.