### PR TITLE
Modify error translator to raise more informative errors

### DIFF
--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -39,15 +39,14 @@ def translate_lakefs_error(
 
     Parameters
     ----------
-
     error: lakefs_client.ApiException
         The exception returned by the lakeFS API.
-    rpath: str or None
+    rpath: str | None
         The remote resource path involved in the error.
-    message : str
+    message: str | None
         An error message to use for the returned exception.
          If not given, the error message returned by the lakeFS server is used instead.
-    set_cause : bool
+    set_cause: bool
         Whether to set the ``__cause__`` attribute to the previous exception if the exception is translated.
 
     Returns
@@ -61,12 +60,11 @@ def translate_lakefs_error(
     else:
         status, reason = error.code, error.reason
 
-    constructor = HTTP_CODE_TO_ERROR.get(status, partial(IOError, errno.EIO))
-
     emsg = f"{status} {reason}"
     if rpath:
         emsg += f": {rpath!r}"
 
+    constructor = HTTP_CODE_TO_ERROR.get(status, partial(IOError, errno.EIO))
     custom_exc = constructor(message or emsg)
 
     if set_cause:

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -8,27 +8,31 @@ avoid complicated error handling setups.
 from __future__ import annotations
 
 import errno
-import functools
 import json
-from typing import Any
+from functools import partial
+from urllib.error import HTTPError
 
 from lakefs_sdk import ApiException
 
-HTTP_CODE_TO_ERROR: dict[int, type[OSError]] = {
+HTTP_CODE_TO_ERROR: dict[int, type[OSError] | partial[OSError]] = {
+    400: partial(IOError, errno.EINVAL),
     401: PermissionError,
     403: PermissionError,
     404: FileNotFoundError,
+    410: FileNotFoundError,  # Gone (temporarily / permanently unavailable)
+    416: partial(IOError, errno.EINVAL),  # invalid range
+    420: partial(IOError, errno.EBUSY),  # too many requests
 }
 
 
 def translate_lakefs_error(
-    error: ApiException,
+    error: ApiException | HTTPError,
+    rpath: str | None = None,
     message: str | None = None,
     set_cause: bool = True,
-    *args: Any,
 ) -> OSError:
     """
-    Convert a lakeFS API exception to a Python builtin exception.
+    Convert a lakeFS API exception or urllib HTTP error to a Python builtin exception.
 
     For some subclasses of ``lakefs_sdk.ApiException``, a direct Python builtin equivalent exists.
     In these cases, the suitable equivalent is returned. All other classes are converted to a standard ``IOError``.
@@ -36,33 +40,41 @@ def translate_lakefs_error(
     Parameters
     ----------
 
-    error : lakefs_client.ApiException
+    error: lakefs_client.ApiException
         The exception returned by the lakeFS API.
+    rpath: str or None
+        The remote resource path involved in the error.
     message : str
         An error message to use for the returned exception.
          If not given, the error message returned by the lakeFS server is used instead.
     set_cause : bool
         Whether to set the ``__cause__`` attribute to the previous exception if the exception is translated.
-    *args:
-        Additional arguments to pass to the exception constructor, after the
-        error message. Useful for passing the filename arguments to ``IOError``.
 
     Returns
     -------
     OSError
         A builtin Python exception ready to be thrown.
     """
-    status, reason, body = error.status, error.reason, error.body
+    if isinstance(error, ApiException):
+        status, body = error.status, error.body
+    else:
+        status, body = error.code, json.dumps({"message": error.reason})
 
-    emsg = f"HTTP{status} ({reason})"
-    try:
-        lakefs_msg = json.loads(body)["message"]
-        emsg += f": {lakefs_msg}"
-    except json.JSONDecodeError:
-        pass
+    constructor = HTTP_CODE_TO_ERROR.get(status, partial(IOError, errno.EIO))
 
-    constructor = HTTP_CODE_TO_ERROR.get(status, functools.partial(IOError, errno.EIO))
-    custom_exc = constructor(message or emsg, *args)
+    if message is not None:
+        eargs = [message]
+    else:
+        lakefs_msg: str = json.loads(body)["message"]
+        eargs = [status, lakefs_msg]
+        if rpath is not None:
+            eargs.append(rpath)
+        if isinstance(constructor, partial):
+            # the partial has the error code already built in
+            eargs = eargs[1:]
+
+    custom_exc = constructor(*eargs)
+
     if set_cause:
         custom_exc.__cause__ = error
     return custom_exc

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -350,7 +350,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         out = self.ls(path, detail=True, **kwargs)
         if not out:
-            raise FileNotFoundError(404, os.strerror(errno.ENOENT), path)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
         return {
             "name": path.rstrip("/"),

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -5,6 +5,7 @@ namely the ``LakeFSFileSystem`` and ``LakeFSFile`` classes.
 
 from __future__ import annotations
 
+import errno
 import io
 import logging
 import mimetypes
@@ -138,7 +139,9 @@ class LakeFSFileSystem(AbstractFileSystem):
         return self.transaction
 
     @contextmanager
-    def wrapped_api_call(self, message: str | None = None, set_cause: bool = True) -> EmptyYield:
+    def wrapped_api_call(
+        self, rpath: str | None = None, message: str | None = None, set_cause: bool = True
+    ) -> EmptyYield:
         """
         A context manager to wrap lakeFS API calls, translating any PI errors to Python-native OS errors.
 
@@ -146,6 +149,8 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         Parameters
         ----------
+        rpath: str | None
+            The remote path involved in the requested API call.
         message: str | None
             A custom error message to emit instead of parsing the API error response.
         set_cause: bool
@@ -154,7 +159,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         try:
             yield
         except ApiException as e:
-            raise translate_lakefs_error(e, message=message, set_cause=set_cause)
+            raise translate_lakefs_error(e, rpath=rpath, message=message, set_cause=set_cause)
 
     def checksum(self, path: str | os.PathLike[str]) -> str | None:
         """
@@ -293,7 +298,8 @@ class LakeFSFileSystem(AbstractFileSystem):
                 )
                 return
 
-        super().get_file(rpath=rpath, lpath=lpath, callback=callback, outfile=outfile, **kwargs)
+        with self.wrapped_api_call(rpath=rpath):
+            super().get_file(rpath, lpath, callback=callback, outfile=outfile, **kwargs)
 
     def info(self, path: str | os.PathLike[str], **kwargs: Any) -> dict[str, Any]:
         """
@@ -340,11 +346,11 @@ class LakeFSFileSystem(AbstractFileSystem):
                 # fall through, retry with `ls` if it's a directory.
                 pass
             except ApiException as e:
-                raise translate_lakefs_error(e)
+                raise translate_lakefs_error(e, rpath=path)
 
         out = self.ls(path, detail=True, **kwargs)
         if not out:
-            raise FileNotFoundError(path)
+            raise FileNotFoundError(404, os.strerror(errno.ENOENT), path)
 
         return {
             "name": path.rstrip("/"),
@@ -398,7 +404,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         info = []
         # stat infos are either the path only (`detail=False`) or a dict full of metadata
-        with self.wrapped_api_call():
+        with self.wrapped_api_call(rpath=path):
             objects = depaginate(self.client.objects_api.list_objects, repository, ref, **kwargs)
             for obj in cast(Iterable[ObjectStats], objects):
                 info.append(
@@ -533,14 +539,11 @@ class LakeFSFileSystem(AbstractFileSystem):
                     if not remote_url.lower().startswith("http"):
                         raise ValueError("Wrong protocol for remote connection")
                     else:
-                        logger.info(f"Begin upload of {lpath}")
+                        logger.debug(f"Begin upload of {lpath}")
                         with urllib.request.urlopen(request):  # nosec [B310:blacklist] # We catch faulty protocols above.
-                            logger.info(f"Successfully uploaded {lpath}")
+                            logger.debug(f"Successfully uploaded {lpath}")
                 except urllib.error.HTTPError as e:
-                    urllib_http_error_as_lakefs_api_exception = ApiException(
-                        status=e.code, reason=e.reason
-                    )
-                    raise translate_lakefs_error(error=urllib_http_error_as_lakefs_api_exception)
+                    raise translate_lakefs_error(e, rpath=rpath)
         else:
             blockstore_type = self.client.config_api.get_config().storage_config.blockstore_type
             # lakeFS blockstore name is "azure", but Azure's fsspec registry entry is "az".
@@ -622,7 +625,8 @@ class LakeFSFileSystem(AbstractFileSystem):
                 storage_options=storage_options,
             )
         else:
-            super().put_file(lpath=lpath, rpath=rpath, callback=callback, **kwargs)
+            with self.wrapped_api_call(rpath=rpath):
+                super().put_file(lpath, rpath, callback=callback, **kwargs)
 
     def rm_file(self, path: str | os.PathLike[str]) -> None:
         """
@@ -638,7 +642,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         path = stringify_path(path)
         repository, branch, resource = parse(path)
 
-        with self.wrapped_api_call():
+        with self.wrapped_api_call(rpath=path):
             self.client.objects_api.delete_object(
                 repository=repository, branch=branch, path=resource
             )
@@ -733,7 +737,7 @@ class LakeFSFile(AbstractBufferedFile):
         """
         repository, branch, resource = parse(self.path)
 
-        with self.fs.wrapped_api_call():
+        with self.fs.wrapped_api_call(rpath=self.path):
             # empty buffer is equivalent to a touch()
             self.buffer.seek(0)
             self.fs.client.objects_api.upload_object(
@@ -811,7 +815,7 @@ class LakeFSFile(AbstractBufferedFile):
             A byte array holding the downloaded data from lakeFS.
         """
         repository, ref, resource = parse(self.path)
-        with self.fs.wrapped_api_call():
+        with self.fs.wrapped_api_call(rpath=self.path):
             return self.fs.client.objects_api.get_object(
                 repository, ref, resource, range=f"bytes={start}-{end - 1}", **self.kwargs
             )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,39 @@
+import json
+from urllib.error import HTTPError
+
+from lakefs_sdk.exceptions import ApiException
+
+from lakefs_spec.errors import translate_lakefs_error
+
+
+def test_error_translation() -> None:
+    rpath = "repo/ref/ohno.txt"
+
+    # first case: lakeFS API error, 401 unauthorized
+    e = ApiException(status=401, reason="unauthorized")
+    e.body = json.dumps({"message": "unauthorized"})
+
+    translated_err = translate_lakefs_error(e, rpath=rpath)
+    assert isinstance(translated_err, PermissionError)
+    assert f"unauthorized: {rpath!r}" in str(translated_err)
+
+    # second case: urllib 403 unauthorized (blockstore put)
+    e = HTTPError("any", 403, "forbidden", None, None)  # type: ignore
+    translated_err = translate_lakefs_error(e, rpath=rpath)
+    assert isinstance(translated_err, PermissionError)
+    assert f"forbidden: {rpath!r}" in str(translated_err)
+
+    # third case: lakeFS API error 420 (corresponds to partial IOError)
+    e = ApiException(status=420, reason="too many requests")
+    e.body = json.dumps({"message": "too many requests"})
+    translated_err = translate_lakefs_error(e, rpath=rpath)
+    assert isinstance(translated_err, OSError)
+    assert f"too many requests: {rpath!r}" in str(translated_err)
+
+    # fourth case: lakeFS API error 400 with a custom message.
+    e = ApiException(status=400, reason="bad request")
+    e.body = json.dumps({"message": "bad request"})
+    message = "oh no!"
+    translated_err = translate_lakefs_error(e, message=message)
+    assert isinstance(translated_err, OSError)
+    assert str(translated_err).endswith(message)

--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -13,7 +13,7 @@ def test_get_nonexistent_file(fs: LakeFSFileSystem, repository: str) -> None:
     """
     rpath = f"{repository}/main/hello-i-no-exist1234.txt"
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match=f"No such file or directory: {rpath!r}"):
         fs.get(rpath, "out.txt")
 
     assert not Path("out.txt").exists()
@@ -26,7 +26,7 @@ def test_get_from_nonexistent_repo(fs: LakeFSFileSystem) -> None:
     """
     rpath = "nonexistent-repo/main/a.txt"
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match=f"not found: {rpath!r}"):
         fs.get(rpath, "out.txt")
 
     assert not Path("out.txt").exists()
@@ -39,7 +39,7 @@ def test_get_from_nonexistent_branch(fs: LakeFSFileSystem, repository: str) -> N
     """
     rpath = f"{repository}/nonexistentbranch/a.txt"
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match=f"not found: {rpath!r}"):
         fs.get(rpath, "out.txt")
 
     assert not Path("out.txt").exists()

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -65,7 +65,7 @@ def test_implicit_branch_creation(
     fs.create_branch_ok = False
     another_non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
     rpath = f"{repository}/{another_non_existing_branch}/{random_file.name}"
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match=f"not found: {rpath!r}"):
         fs.put(lpath, rpath)
 
 
@@ -73,7 +73,7 @@ def test_put_client_caching(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
     """
-    Tests that `precheck=True` prevents a second upload of an identical file by matching checksums.
+    Tests that ``precheck=True`` prevents a second upload of an identical file by matching checksums.
     """
     fs.client, counter = with_counter(fs.client)
 


### PR DESCRIPTION
Prepares the `status`, `reason`, and `filename` arguments unconditionally for each observed API error.

This way, users who see translated errors actually know what the filename involved is instead of just getting the (less than ideal) lakeFS API reason.

One particular behavior is that of `fs.ls()` in case the branch/ref is not found: Here, unlike in the repository case, the branch is not part of the error message, which means just a generic "file not found" error.

We use OS Errnos for more exotic statuscodes, and HTTP codes for 401, 403 and 404 errors.