### PR TITLE
Docs: Add call to action for early adopters to README and landing page [ENG-186]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Highlights:
 - Zero-config option through config autodiscovery
 - Automatic up-/download management to avoid unnecessary transfers for unchanged files
 
+> [!NOTE]
+> lakeFS-spec is a young project - we are looking for early adopters!
+> Please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions) if you are interested in using the library and want to get in touch with us.
+
 ## Installation
 
 lakeFS-spec is published on PyPI, you can simply install it using your favorite package manager:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Highlights:
 - Automatic up-/download management to avoid unnecessary transfers for unchanged files
 
 > [!NOTE]
-> lakeFS-spec is a young project - we are looking for early adopters!
-> Please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions) if you are interested in using the library and want to get in touch with us.
+> We are seeking early adopters who would like to actively participate in our feedback process and shape the future of the library.
+If you are interested in using the library and want to get in touch with us, please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,8 @@
 # lakefs-spec: An fsspec backend for lakeFS
 
 !!! tip "Early Adopters"
-    lakeFS-spec is a young project - we are looking for early adopters!
-
-    Please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions){: target="_blank" rel="noopener"} if you are interested in using the library and want to get in touch with us.
+    We are seeking early adopters who would like to actively participate in our feedback process and shape the future of the library.
+    If you are interested in using the library and want to get in touch with us, please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions){: target="_blank" rel="noopener"}.
 
 Welcome to lakeFS-spec, a [filesystem-spec](https://github.com/fsspec/filesystem_spec){: target="_blank" rel="noopener"} backend implementation for the [lakeFS](https://lakefs.io/){: target="_blank" rel="noopener"} data lake.
 Our primary goal is to streamline versioned data operations in lakeFS, enabling seamless integration with popular data science tools such as Pandas, Polars, and DuckDB directly from Python.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,11 @@
 # lakefs-spec: An fsspec backend for lakeFS
 
-Welcome to lakeFS-spec, a [filesystem-spec](https://github.com/fsspec/filesystem_spec) backend implementation for the [lakeFS](https://lakefs.io/) data lake.
+!!! tip "Early Adopters"
+    lakeFS-spec is a young project - we are looking for early adopters!
+
+    Please reach out via [Github Discussions](https://github.com/aai-institute/lakefs-spec/discussions){: target="_blank" rel="noopener"} if you are interested in using the library and want to get in touch with us.
+
+Welcome to lakeFS-spec, a [filesystem-spec](https://github.com/fsspec/filesystem_spec){: target="_blank" rel="noopener"} backend implementation for the [lakeFS](https://lakefs.io/){: target="_blank" rel="noopener"} data lake.
 Our primary goal is to streamline versioned data operations in lakeFS, enabling seamless integration with popular data science tools such as Pandas, Polars, and DuckDB directly from Python.
 
 Highlights:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ iniconfig==2.0.0
 lakefs-sdk==1.3.0
 nodeenv==1.8.0
 packaging==23.2
-platformdirs==4.0.0
+platformdirs==4.1.0
 pluggy==1.3.0
 pre-commit==3.5.0
 pydantic==1.10.13

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -35,7 +35,7 @@ fsspec==2023.12.0
 ghp-import==2.1.0
 gitdb==4.0.11
 gitpython==3.1.40
-griffe==0.38.0
+griffe==0.38.1
 h11==0.14.0
 httpcore==1.0.2
 httpx==0.25.2
@@ -58,7 +58,7 @@ jupyter-console==6.6.3
 jupyter-core==5.5.0
 jupyter-events==0.9.0
 jupyter-lsp==2.2.1
-jupyter-server==2.11.1
+jupyter-server==2.12.1
 jupyter-server-terminals==0.4.4
 jupyterlab==4.0.9
 jupyterlab-pygments==0.3.0
@@ -82,7 +82,7 @@ mkdocs-gen-files==0.5.0
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-include-dir-to-nav==1.2.0
 mkdocs-literate-nav==0.6.1
-mkdocs-material==9.4.14
+mkdocs-material==9.5.0
 mkdocs-material-extensions==1.3.1
 mkdocs-section-index==0.3.8
 mkdocstrings[python]==0.24.0
@@ -90,7 +90,7 @@ mkdocstrings-python==1.7.5
 mknotebooks==0.8.0
 mypy-extensions==1.0.0
 nbclient==0.9.0
-nbconvert==7.11.0
+nbconvert==7.12.0
 nbformat==5.9.2
 neoteroi-mkdocs==1.0.4
 nest-asyncio==1.5.8
@@ -103,7 +103,7 @@ pandocfilters==1.5.0
 parso==0.8.3
 pathspec==0.11.2
 pexpect==4.9.0
-platformdirs==4.0.0
+platformdirs==4.1.0
 prometheus-client==0.19.0
 prompt-toolkit==3.0.41
 psutil==5.9.6
@@ -119,10 +119,10 @@ python-json-logger==2.0.7
 pytz==2023.3.post1
 pyyaml==6.0.1
 pyyaml-env-tag==0.1
-pyzmq==25.1.1
+pyzmq==25.1.2
 qtconsole==5.5.1
 qtpy==2.4.1
-referencing==0.31.1
+referencing==0.32.0
 regex==2023.10.3
 requests==2.31.0
 rfc3339-validator==0.1.4

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -82,7 +82,7 @@ mkdocs-gen-files==0.5.0
 mkdocs-git-revision-date-localized-plugin==1.2.1
 mkdocs-include-dir-to-nav==1.2.0
 mkdocs-literate-nav==0.6.1
-mkdocs-material==9.5.0
+mkdocs-material==9.5.1
 mkdocs-material-extensions==1.3.1
 mkdocs-section-index==0.3.8
 mkdocstrings[python]==0.24.0


### PR DESCRIPTION
This PR adds a call to action to early adopters to the documentation landing page and (repository) README.

https://github.com/aai-institute/lakefs-spec/security/dependabot/8 is addressed by updating the documentation dependencies.