### PR TITLE
`ls`: Make non-recursive by default, correctly update dircache

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -341,7 +341,7 @@ def reset_branch(client: LakeFSClient, repository: str, branch: str) -> None:
     repository: str
         Repository in which the specified branch is located.
     branch: str
-        Branch on which the commit should be reverted.
+        Branch to reset.
     """
     reset_creation = ResetCreation(type="reset")
     client.branches_api.reset_branch(

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -21,6 +21,7 @@ from lakefs_sdk.models import (
     Ref,
     Repository,
     RepositoryCreation,
+    ResetCreation,
     RevertCreation,
     TagCreation,
 )
@@ -326,6 +327,25 @@ def revert(client: LakeFSClient, repository: str, branch: str, parent_number: in
     revert_creation = RevertCreation(ref=branch, parent_number=parent_number)
     client.branches_api.revert_branch(
         repository=repository, branch=branch, revert_creation=revert_creation
+    )
+
+
+def reset_branch(client: LakeFSClient, repository: str, branch: str) -> None:
+    """
+    Reset the specified branch to its head.
+
+    Parameters
+    ----------
+    client: LakeFSClient
+        lakeFS client object.
+    repository: str
+        Repository in which the specified branch is located.
+    branch: str
+        Branch on which the commit should be reverted.
+    """
+    reset_creation = ResetCreation(type="reset")
+    client.branches_api.reset_branch(
+        repository=repository, branch=branch, reset_creation=reset_creation
     )
 
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -446,6 +446,13 @@ class LakeFSFileSystem(AbstractFileSystem):
                     }
                 )
 
+        # Retry the API call with appended slash if the current result
+        # is just a single directory entry only (not its contents).
+        # This is useful to allow `ls("repo/branch/dir")` calls without
+        # a trailing slash.
+        if len(info) == 1 and info[0]["type"] == "directory":
+            return self.ls(path + "/", detail=detail, **kwargs | {"refresh": not use_dircache})
+
         # cache the info if not empty.
         if info:
             # assumes that the returned info is name-sorted.

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -396,7 +396,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             else:
                 raise ValueError(f"unexpected path type {path_type!r}")
 
-        path = stringify_path(path)
+        path = cast(str, stringify_path(path))
         repository, ref, prefix = parse(path)
 
         # Try lookup in dircache unless explicitly disabled by `refresh=True` kwarg
@@ -451,7 +451,11 @@ class LakeFSFileSystem(AbstractFileSystem):
         # This is useful to allow `ls("repo/branch/dir")` calls without
         # a trailing slash.
         if len(info) == 1 and info[0]["type"] == "directory":
-            return self.ls(path + "/", detail=detail, **kwargs | {"refresh": not use_dircache})
+            return self.ls(
+                path + "/",
+                detail=detail,
+                **kwargs | {"refresh": not use_dircache, "recursive": recursive},
+            )
 
         # cache the info if not empty.
         if info:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -386,6 +386,16 @@ class LakeFSFileSystem(AbstractFileSystem):
         list[str | dict[str, Any]]
             A list of all objects' metadata under the given remote path if ``detail=True``, or alternatively only their names if ``detail=False``.
         """
+
+        def _api_path_type_to_info(path_type: str) -> Literal["file", "directory"]:
+            """Convert ``list_objects()`` API response field ``path_type`` to ``info.type``."""
+            if path_type == "object":
+                return "file"
+            elif path_type == "common_prefix":
+                return "directory"
+            else:
+                raise ValueError(f"unexpected path type {path_type!r}")
+
         path = stringify_path(path)
         repository, ref, prefix = parse(path)
 
@@ -432,7 +442,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                         "mtime": obj.mtime,
                         "name": f"{repository}/{ref}/{obj.path}",
                         "size": obj.size_bytes,
-                        "type": "file",
+                        "type": _api_path_type_to_info(obj.path_type),
                     }
                 )
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -409,9 +409,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                     return [e["name"] for e in cache_entry]
                 return cache_entry[:]
 
-        recursive = kwargs.get("recursive", False)
-        if "recursive" in kwargs:
-            del kwargs["recursive"]
+        recursive = kwargs.pop("recursive", False)
 
         kwargs["prefix"] = prefix
 
@@ -441,9 +439,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         # cache the info if not empty.
         if info:
             # assumes that the returned info is name-sorted.
-            # All directories included in this listing
-            directories = {str(Path(e["name"]).parent) for e in info}
-
             pp = self._parent(info[0]["name"])
             info_copy = info[:]
             if pp in self.dircache:
@@ -689,9 +684,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                 repository=repository, branch=branch, path=resource
             )
             # Directory listing cache for the containing folder must be invalidated
-            parent_path = str(Path(path).parent)
-            if parent_path in self.dircache:
-                del self.dircache[parent_path]
+            self.dircache.pop(self._parent(path), None)
 
 
 class LakeFSFile(AbstractBufferedFile):

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -255,3 +255,21 @@ def test_delete_undefined_branch_error(fs: LakeFSFileSystem, repository: str) ->
         client_helpers.delete_branch(
             fs.client, repository=repository, branch=not_existing_branch_name, missing_ok=False
         )
+
+
+def test_reset_branch(
+    fs: LakeFSFileSystem,
+    repository: str,
+    random_file_factory: RandomFileFactory,
+) -> None:
+    branch = "main"
+
+    lpath = random_file_factory.make()
+    lpath.write_text("Hello")
+
+    rpath = f"lakefs://{repository}/{branch}/{lpath.name}"
+
+    fs.put(str(lpath), rpath)
+    client_helpers.reset_branch(fs.client, repository, branch)
+    with pytest.raises(FileNotFoundError):
+        fs.info(rpath)

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -105,6 +105,8 @@ def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
 
     # ...as well as the cache fetch.
     assert fs.ls(resource, detail=False) == expected
+
+    # One API call for the directory object, and one for listing its contents
     assert counter.count("objects_api.list_objects") == 2
 
     # test the same thing with a subfolder + file prefix

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -100,7 +100,7 @@ def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
 
     expected = [f"{resource}/lakes.source.md"]
     # first, verify the API fetch does the expected...
-    assert fs.ls(f"{resource}", detail=False) == expected
+    assert fs.ls(resource, detail=False) == expected
     assert list(fs.dircache.keys()) == [resource]
 
     # ...as well as the cache fetch.

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,8 +1,11 @@
+import pytest
+
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory, with_counter
 
 
-def test_paginated_ls(fs: LakeFSFileSystem, repository: str) -> None:
+@pytest.mark.parametrize("pagesize", [1, 2, 5, 10, 50])
+def test_paginated_ls(fs: LakeFSFileSystem, repository: str, pagesize: int) -> None:
     """
     Check that all results of an ``ls`` call are returned independently of page size.
     """
@@ -11,9 +14,8 @@ def test_paginated_ls(fs: LakeFSFileSystem, repository: str) -> None:
     # default amount of 100 objects per page
     all_results = fs.ls(resource)
 
-    for pagesize in [2, 5, 10, 50]:
-        paged_results = fs.ls(resource, amount=pagesize)
-        assert paged_results == all_results
+    paged_results = fs.ls(resource, amount=pagesize, refresh=True)
+    assert paged_results == all_results
 
 
 def test_ls_caching(fs: LakeFSFileSystem, repository: str) -> None:

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -100,12 +100,12 @@ def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
 
     expected = [f"{resource}/lakes.source.md"]
     # first, verify the API fetch does the expected...
-    assert fs.ls(f"{resource}/", detail=False) == expected
+    assert fs.ls(f"{resource}", detail=False) == expected
     assert list(fs.dircache.keys()) == [resource]
 
     # ...as well as the cache fetch.
     assert fs.ls(resource, detail=False) == expected
-    assert counter.count("objects_api.list_objects") == 1
+    assert counter.count("objects_api.list_objects") == 2
 
     # test the same thing with a subfolder + file prefix
     resource = f"{prefix}/images/duckdb"


### PR DESCRIPTION
This PR combines various fixes to the handling of the directory listing cache and `ls` behavior in general:

## 🚨 Breaking Change: Make `ls` non-recursive by default
The `ls` method in its previous implementation would always return items in subdirectories recursively, which is not an intuitive behavior.

This PR introduces an optional `recursive` kwarg, which is set to `False` by default.

## `ls` dircache update
The `ls` command was not updating the dircache correctly, which could lead to incorrect results when listing the same directory multiple times.

In particular, the implementation would always add all results from the API call to the dircache for the directory, regardless of whether the results were already in the cache entry (essentially doubling the cache entry for each subsequent call).

This behavior would only be triggered by passing `refresh=True`, which bypasses the shortcut evaluation that returns a dircache entry directly.

## `rm` dircache invalidation
Additionally, this PR fixes the invalidation of the dircache as part of `rm`.

Removing a file from the repository obviously makes any cache directory listing of its parent directory invalid, which is now handled correctly (and tested).