### PR TITLE
Improve test coverage on lakefs abstract base classes

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       lakefs:
-        image: treeverse/lakefs:1.3.0
+        image: treeverse/lakefs:1.3.1
         ports:
           - 8000:8000
         env:
@@ -31,40 +31,40 @@ jobs:
       RUFF_CACHE_DIR: "${{ github.workspace }}/.cache/ruff"
       PRE_COMMIT_HOME: "${{ github.workspace }}/.cache/pre-commit"
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0  # for documentation builds
-    - name: Set up Python and dependencies
-      uses: ./.github/actions/python-deps
-      with:
-        pythonVersion: 3.11
-    - name: Cache pre-commit tools
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ env.MYPY_CACHE_DIR }}
-          ${{ env.RUFF_CACHE_DIR }}
-          ${{ env.PRE_COMMIT_HOME }}
-        key: ${{ runner.os }}-${{ hashFiles('requirements-dev.txt', '.pre-commit-config.yaml') }}-linter-cache
-    - name: Run pre-commit checks
-      run: |
-        pre-commit run --all-files --verbose --show-diff-on-failure
-    - name: Set up oldest supported Python for testing (3.9)
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - name: Test on oldest supported Python
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
-        pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    - name: Documentation
-      uses: ./.github/actions/mike-docs
-      with:
-        version: development
-        pre_release: true  # include pre-release notification banner
-        push: ${{ github.ref == 'refs/heads/main' }}  # build always, publish on 'main' only to prevent version clutter
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # for documentation builds
+      - name: Set up Python and dependencies
+        uses: ./.github/actions/python-deps
+        with:
+          pythonVersion: 3.11
+      - name: Cache pre-commit tools
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.MYPY_CACHE_DIR }}
+            ${{ env.RUFF_CACHE_DIR }}
+            ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ runner.os }}-${{ hashFiles('requirements-dev.txt', '.pre-commit-config.yaml') }}-linter-cache
+      - name: Run pre-commit checks
+        run: |
+          pre-commit run --all-files --verbose --show-diff-on-failure
+      - name: Set up oldest supported Python for testing (3.9)
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Test on oldest supported Python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Documentation
+        uses: ./.github/actions/mike-docs
+        with:
+          version: development
+          pre_release: true # include pre-release notification banner
+          push: ${{ github.ref == 'refs/heads/main' }} # build always, publish on 'main' only to prevent version clutter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ jobs:
     name: Build source distribution and wheel
     runs-on: ubuntu-latest
     services:
-      lakefs:  # required for building documentation
-        image: treeverse/lakefs:1.3.0
+      lakefs: # required for building documentation
+        image: treeverse/lakefs:1.3.1
         ports:
           - 8000:8000
         env:
@@ -26,7 +26,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # for documentation builds
+          fetch-depth: 0 # for documentation builds
       - name: Set up Python and dependencies
         uses: ./.github/actions/python-deps
         with:
@@ -47,7 +47,7 @@ jobs:
           push: true
   publish_pypi:
     name: Publish wheels to PyPI
-    needs: [ build ]
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -60,7 +60,7 @@ jobs:
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          skip-existing: true  # tolerate release package file duplicates
+          skip-existing: true # tolerate release package file duplicates
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 
 services:
   lakefs:
-    image: treeverse/lakefs:1.3.0
+    image: treeverse/lakefs:1.3.1
     ports:
       - 8000:8000
     environment:

--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -13,7 +13,7 @@ services:
       - ./config/s3.json:/etc/seaweedfs/s3.json
 
   lakefs:
-    image: treeverse/lakefs:1.3.0
+    image: treeverse/lakefs:1.3.1
     network_mode: host
     depends_on:
       - seaweedfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,6 @@ exclude_dirs = ["tests", "docs/tutorials"]
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "WARNING"
+
+[tool.coverage.report]
+exclude_lines = ["pragma: not covered", "@overload"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ filelock==3.13.1
 fsspec==2023.12.0
 identify==2.5.32
 iniconfig==2.0.0
-lakefs-sdk==1.3.0
+lakefs-sdk==1.3.1
 nodeenv==1.8.0
 packaging==23.2
 platformdirs==4.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -65,7 +65,7 @@ jupyterlab-pygments==0.3.0
 jupyterlab-server==2.25.2
 jupyterlab-widgets==3.0.9
 jupytext==1.16.0
-lakefs-sdk==1.3.0
+lakefs-sdk==1.3.1
 markdown==3.5.1
 markdown-it-py==3.0.0
 markupsafe==2.1.3

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -163,7 +163,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self, rpath: str | None = None, message: str | None = None, set_cause: bool = True
     ) -> EmptyYield:
         """
-        A context manager to wrap lakeFS API calls, translating any PI errors to Python-native OS errors.
+        A context manager to wrap lakeFS API calls, translating any API errors to Python-native OS errors.
 
         Meant for internal use.
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -618,8 +618,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                         raise ValueError("Wrong protocol for remote connection")
                     else:
                         logger.debug(f"Begin upload of {lpath}")
-                        # nosec [B310:blacklist] # We catch faulty protocols above.
-                        with urllib.request.urlopen(request):
+                        with urllib.request.urlopen(request):  # nosec [B310:blacklist] # We catch faulty protocols above.
                             logger.debug(f"Successfully uploaded {lpath}")
                 except urllib.error.HTTPError as e:
                     raise translate_lakefs_error(e, rpath=rpath)

--- a/tests/smoke_tests/test_abstractfile.py
+++ b/tests/smoke_tests/test_abstractfile.py
@@ -27,13 +27,3 @@ def test_readline(
             assert rf.readlines() == native_open_lines
     finally:
         lpath.unlink(missing_ok=True)
-
-
-def test_touch(
-    fs: LakeFSFileSystem,
-    repository: str,
-    temp_branch: str,
-) -> None:
-    rpath = f"{repository}/{temp_branch}/hello.txt"
-    fs.touch(rpath)
-    assert fs.exists(rpath)

--- a/tests/smoke_tests/test_abstractfile.py
+++ b/tests/smoke_tests/test_abstractfile.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_readline(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    """Checks that `fs.open()` behaves like builtin `open` for `readline(s)` APIs."""
+    lpath = Path("random_file.txt")
+    try:
+        lpath.write_text("Hello\nmy name is\nxyz")
+        with open(lpath, "rb") as f:
+            native_open_line = f.readline()
+            f.seek(0)
+            native_open_lines = f.readlines()
+
+        rpath = f"{repository}/{temp_branch}/{Path(lpath).name}"
+        fs.put_file(lpath, rpath)
+
+        with fs.open(rpath, "rb") as rf:
+            # mode == "rb" means everything is bytes.
+            assert rf.readline() == native_open_line
+            rf.seek(0)
+            assert rf.readlines() == native_open_lines
+    finally:
+        lpath.unlink(missing_ok=True)
+
+
+def test_touch(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"{repository}/{temp_branch}/hello.txt"
+    fs.touch(rpath)
+    assert fs.exists(rpath)

--- a/tests/smoke_tests/test_abstractfile.py
+++ b/tests/smoke_tests/test_abstractfile.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from lakefs_spec.spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
 
 
 def test_readline(
@@ -27,3 +28,15 @@ def test_readline(
             assert rf.readlines() == native_open_lines
     finally:
         lpath.unlink(missing_ok=True)
+
+
+def test_info(
+    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
+    rnd_file = random_file_factory.make()
+    rpath = f"{repository}/{temp_branch}/{rnd_file.name}"
+    fs.put(str(rnd_file), rpath)
+    details = fs.open(rpath).info()
+    expected_keys = ["checksum", "content-type", "mtime", "name", "size", "type"]
+    for key in expected_keys:
+        assert key in details.keys()

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -170,12 +170,35 @@ def test_mv(
 ) -> None:
     random_file = random_file_factory.make()
     lpath = str(random_file)
-    rpath = f"{repository}/{temp_branch}/new_dir/{random_file.name}"
+    rpath1 = f"{repository}/{temp_branch}/new_dir/{random_file.name}"
+    rpath2 = f"{repository}/{temp_branch}/{random_file.name}"
 
-    fs.put_file(lpath=lpath, rpath=rpath)
-    assert fs.exists(rpath)
-    assert not fs.exists(f"{repository}/{temp_branch}/{random_file.name}")
+    fs.put_file(lpath=lpath, rpath=rpath1)
+    assert fs.exists(rpath1)
+    assert not fs.exists(rpath2)
 
-    fs.mv(rpath, f"{repository}/{temp_branch}/{random_file.name}")
-    assert not fs.exists(rpath)
-    assert fs.exists(f"{repository}/{temp_branch}/{random_file.name}")
+    fs.mv(rpath1, rpath2)
+    assert not fs.exists(rpath1)
+    assert fs.exists(rpath2)
+
+
+def test_copy(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    random_file = random_file_factory.make()
+    lpath = str(random_file)
+    rpath1 = f"{repository}/{temp_branch}/new_dir/{random_file.name}"
+    rpath2 = f"{repository}/{temp_branch}/{random_file.name}"
+
+    fs.put_file(lpath=lpath, rpath=rpath1)
+    assert fs.exists(rpath1)
+    assert not fs.exists(rpath2)
+
+    fs.cp(rpath1, rpath2)
+    assert fs.exists(rpath1)
+    assert fs.exists(rpath2)
+
+    assert fs.info(rpath1)["checksum"] == fs.info(rpath2)["checksum"]

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -22,3 +22,9 @@ def test_walk_repo_root(fs: LakeFSFileSystem, repository: str) -> None:
     assert dirname == path
     assert len(dirs) == 2
     assert len(files) == 2
+
+
+def test_find_in_folder(fs: LakeFSFileSystem, repository: str) -> None:
+    path = f"{repository}/main/"
+    # Find the 37 elements in images directory in test repo
+    assert len(fs.find(path + "images")) == 37

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -8,7 +8,7 @@ def test_walk_single_dir(fs: LakeFSFileSystem, repository: str) -> None:
     path = f"{repository}/{branch}/{resource}/"
 
     dirname, dirs, files = next(fs.walk(path))
-    assert dirname == path.rstrip("/")
+    assert dirname == path
     assert dirs == []
     assert len(files) == 37  # NOTE: hardcoded for quickstart repo
 

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -28,3 +28,133 @@ def test_find_in_folder(fs: LakeFSFileSystem, repository: str) -> None:
     path = f"{repository}/main/"
     # Find the 37 elements in images directory in test repo
     assert len(fs.find(path + "images")) == 37
+
+
+def test_touch(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"{repository}/{temp_branch}/hello.txt"
+    fs.touch(rpath)
+    assert fs.exists(rpath)
+
+
+def test_glob(
+    fs: LakeFSFileSystem,
+    repository: str,
+) -> None:
+    branch = "main"
+    files = fs.glob(f"lakefs://{repository}/{branch}/**/*.png")
+    assert len(files) > 0
+
+
+def test_du(
+    fs: LakeFSFileSystem,
+    repository: str,
+) -> None:
+    branch = "main"
+    size = fs.du(f"lakefs://{repository}/{branch}/", withdirs=True)
+    assert size > 2**20  # at least 1 MiB in the quickstart repo
+
+
+def test_size(
+    fs: LakeFSFileSystem,
+    repository: str,
+) -> None:
+    branch = "main"
+    size = fs.size(f"lakefs://{repository}/{branch}/lakes.parquet")
+    assert size >= 2**19  # lakes.parquet is larger than 500 KiB
+
+
+def test_isfile_isdir(
+    fs: LakeFSFileSystem,
+    repository: str,
+) -> None:
+    branch = "main"
+    assert fs.isfile(f"lakefs://{repository}/{branch}/lakes.parquet")
+    assert not fs.isdir(f"lakefs://{repository}/{branch}/lakes.parquet")
+
+    assert not fs.isfile(f"lakefs://{repository}/{branch}/data")
+    assert fs.isdir(f"lakefs://{repository}/{branch}/data")
+
+
+def test_write_text_read_text(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"lakefs://{repository}/{temp_branch}/new-file.txt"
+    content = "Hello, World!"
+    encoding = "utf-32-le"  # use a non-standard encoding
+
+    fs.write_text(rpath, content, encoding=encoding)
+    actual = fs.read_text(rpath, encoding=encoding)
+    assert actual == content
+
+
+def test_cat_pipe(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"lakefs://{repository}/{temp_branch}/new-file.txt"
+    content = "Hello, World!"
+    encoding = "utf-32-le"  # use a non-standard encoding
+    fs.pipe(rpath, content.encode(encoding))
+
+    actual = fs.cat(rpath)
+    assert str(actual, encoding=encoding) == content
+
+    actual = fs.cat_file(rpath, end=4)  # Only fetch first UTF-32 glyph
+    assert str(actual, encoding=encoding) == content[0]
+
+
+def test_cat_pipe_file(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"lakefs://{repository}/{temp_branch}/new-file.txt"
+    content = "Hello, World!"
+    encoding = "utf-32-le"  # use a non-standard encoding
+    fs.pipe_file(rpath, content.encode(encoding))
+
+    actual = fs.cat(rpath)
+    assert str(actual, encoding=encoding) == content
+
+
+def test_cat_ranges(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpaths = [f"lakefs://{repository}/{temp_branch}/file-{idx}.txt" for idx in range(2)]
+    content = "Hello, World!"
+    encoding = "utf8"
+
+    fs.write_text(rpaths[0], content, encoding=encoding)
+    fs.write_text(rpaths[1], content, encoding=encoding)
+
+    ranges = fs.cat_ranges(rpaths, starts=0, ends=1)  # fetch first byte of each file
+    for idx in range(2):
+        assert str(ranges[idx], encoding=encoding) == content[0]
+
+
+def test_head_tail(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    rpath = f"lakefs://{repository}/{temp_branch}/new-file.txt"
+    content = "Hello, World!"
+    encoding = "utf-8"
+
+    fs.write_text(rpath, content, encoding=encoding)
+
+    size = 2
+    head = fs.head(rpath, size=size)
+    assert str(head, encoding=encoding) == content[:size]
+
+    tail = fs.tail(rpath, size=size)
+    assert str(tail, encoding=encoding) == content[len(content) - size :]

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -1,0 +1,24 @@
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_walk_single_dir(fs: LakeFSFileSystem, repository: str) -> None:
+    """`walk` in a single directory should find all files contained therein"""
+    branch = "main"
+    resource = "images"
+    path = f"{repository}/{branch}/{resource}/"
+
+    dirname, dirs, files = next(fs.walk(path))
+    assert dirname == path.rstrip("/")
+    assert dirs == []
+    assert len(files) == 37  # NOTE: hardcoded for quickstart repo
+
+
+def test_walk_repo_root(fs: LakeFSFileSystem, repository: str) -> None:
+    """`walk` should be able to be called on the root directory of a repository"""
+    branch = "main"
+    path = f"{repository}/{branch}/"
+
+    dirname, dirs, files = next(fs.walk(path))
+    assert dirname == path
+    assert len(dirs) == 2
+    assert len(files) == 2

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+from typing import TypeAlias
+
+import pytest
+
+from lakefs_spec import LakeFSFileSystem
+
+AnyPath: TypeAlias = str | os.PathLike[str] | Path
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # base case
+        ("lakefs://repo/ref/a.txt", "repo/ref/a.txt"),
+        # does not strip trailing slash
+        ("lakefs://repo/ref/", "repo/ref/"),
+        # can accept Path
+        (Path("repo/ref/a.txt"), "repo/ref/a.txt"),
+        # Works on lists as well
+        (
+            ["lakefs://repo/ref/a.txt", "lakefs://repo/ref/b.txt"],
+            ["repo/ref/a.txt", "repo/ref/b.txt"],
+        ),
+    ],
+)
+def test_strip_protocol(
+    fs: LakeFSFileSystem,
+    path: AnyPath | list[AnyPath],
+    expected: str | list[str],
+) -> None:
+    actual = fs._strip_protocol(path)
+    assert actual == expected

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,8 +1,8 @@
 import os
 from pathlib import Path
-from typing import TypeAlias
 
 import pytest
+from typing_extensions import TypeAlias
 
 from lakefs_spec import LakeFSFileSystem
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,12 +1,13 @@
 import os
 from pathlib import Path
+from typing import Union
 
 import pytest
 from typing_extensions import TypeAlias
 
 from lakefs_spec import LakeFSFileSystem
 
-AnyPath: TypeAlias = str | os.PathLike[str] | Path
+AnyPath: TypeAlias = Union[str, os.PathLike[str], Path]
 
 
 @pytest.mark.parametrize(
@@ -27,8 +28,8 @@ AnyPath: TypeAlias = str | os.PathLike[str] | Path
 )
 def test_strip_protocol(
     fs: LakeFSFileSystem,
-    path: AnyPath | list[AnyPath],
-    expected: str | list[str],
+    path: Union[AnyPath, list[AnyPath]],
+    expected: Union[str, list[str]],
 ) -> None:
     actual = fs._strip_protocol(path)
     assert actual == expected

--- a/tests/test_spec_utils.py
+++ b/tests/test_spec_utils.py
@@ -1,61 +1,45 @@
+from typing import ContextManager
+
 import pytest
 
 from lakefs_spec.spec import parse
 
 
-def test_path_parsing():
-    # case 1: well-formed path input
-    path = "my-repo/my-ref/resource.txt"
-    repo, ref, resource = parse(path)
-    assert repo == "my-repo"
-    assert ref == "my-ref"
-    assert resource == "resource.txt"
+@pytest.mark.parametrize(
+    "path,repo,ref,resource",
+    [
+        # case 1: well-formed path input
+        ("my-repo/my-ref/resource.txt", "my-repo", "my-ref", "resource.txt"),
+        # case 2: nested resource
+        ("my-repo/my-ref/my/nested/resource.txt", "my-repo", "my-ref", "my/nested/resource.txt"),
+        # case 3: top-level resource
+        ("my-repo/my-ref/", "my-repo", "my-ref", ""),
+        # case 4: single-character branch
+        ("my-repo/a/resource.txt", "my-repo", "a", "resource.txt"),
+        # case 5: well-formed path with leading lakefs:// scheme
+        ("lakefs://my-repo/my-ref/resource.txt", "my-repo", "my-ref", "resource.txt"),
+    ],
+)
+def test_path_parsing_success(path: str, repo: str, ref: str, resource: str) -> None:
+    act_repo, act_ref, act_resource = parse(path)
+    assert act_repo == repo
+    assert act_ref == ref
+    assert act_resource == resource
 
-    # case 2: nested resource
-    path = "my-repo/my-ref/my/nested/resource.txt"
-    repo, ref, resource = parse(path)
-    assert repo == "my-repo"
-    assert ref == "my-ref"
-    assert resource == "my/nested/resource.txt"
 
-    # case 3: top-level resource
-    path = "my-repo/my-ref/"
-    repo, ref, resource = parse(path)
-    assert repo == "my-repo"
-    assert ref == "my-ref"
-    assert resource == ""
-
-    # case 4: single-character branch
-    path = "my-repo/a/resource.txt"
-    repo, ref, resource = parse(path)
-    assert repo == "my-repo"
-    assert ref == "a"
-    assert resource == "resource.txt"
-
-    # case 5: well-formed path with leading lakefs:// scheme
-    path = "lakefs://my-repo/my-ref/resource.txt"
-    repo, ref, resource = parse(path)
-    assert repo == "my-repo"
-    assert ref == "my-ref"
-    assert resource == "resource.txt"
-
-    # ----------------- Failure cases -------------------
-    # repo name illegally begins with hyphen
-    path = "-repo/my-ref/resource.txt"
-    with pytest.raises(ValueError, match="expected path .*"):
-        parse(path)
-
-    # repo name contains an illegal uppercase letter
-    path = "Repo/my-ref/resource.txt"
-    with pytest.raises(ValueError, match="expected path .*"):
-        parse(path)
-
-    # missing repo name
-    path = "my-ref/resource.txt"
-    with pytest.raises(ValueError, match="expected path .*"):
-        parse(path)
-
-    # illegal branch name
-    path = "my-repo/my-ref$$$/resource.txt"
-    with pytest.raises(ValueError, match="expected path .*"):
+@pytest.mark.parametrize(
+    "path,expected_exception",
+    [
+        # repo name illegally begins with hyphen
+        ("-repo/my-ref/resource.txt", pytest.raises(ValueError, match="expected path .*")),
+        # repo name contains an illegal uppercase letter
+        ("Repo/my-ref/resource.txt", pytest.raises(ValueError, match="expected path .*")),
+        # missing repo name
+        ("my-ref/resource.txt", pytest.raises(ValueError, match="expected path .*")),
+        # illegal branch name
+        ("repo/my-ref$$$/resource.txt", pytest.raises(ValueError, match="expected path .*")),
+    ],
+)
+def test_path_parsing_failure(path: str, expected_exception: ContextManager) -> None:
+    with expected_exception:
         parse(path)


### PR DESCRIPTION
This PR adds a variety of smoke tests that aim to cover the default functionality provided by the abstract base classes from `fsspec`, namely `AbstractFileSystem` and `AbstractBufferedFile`.

In order to avoid the problem discovered by one of the tests and reported upstream ( https://github.com/treeverse/lakeFS/issues/7127), the version of lakeFS dependencies has been bumped to v1.3.1 in the CI and dev environments.

> [!NOTE]
> These tests are not meant to provide complete coverage of the base implementations, since these are tested as part of `fsspec` already.
> Rather, they aim to uncover any potential issues that arise from the mix of overwritten and default implementations and their interactions (e.g., quite a few implementations in the ABC rely on the return value from `ls`, which is overwritten in the library).