### PR TITLE
Validate with docstrings with `pydoclint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,7 @@ repos:
           - --output-file=requirements-docs.txt
           - pyproject.toml
         files: ^(pyproject\.toml|requirements-docs\.txt)$
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.3.8
+    hooks:
+      - id: pydoclint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pre-commit>=3.3.3",
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
+    "pydoclint",
 ]
 docs = [
     "mkdocs",
@@ -123,3 +124,7 @@ exclude_dirs = ["tests", "docs/tutorials"]
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "WARNING"
+
+[tool.pydoclint]
+style = 'numpy'
+exclude = '\.git|venv'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,10 @@
 aenum==3.1.15
 build==1.0.3
 cfgv==3.4.0
+click==8.1.7
 coverage[toml]==7.3.2
 distlib==0.3.7
+docstring-parser-fork==0.0.5
 filelock==3.13.1
 fsspec==2023.12.0
 identify==2.5.32
@@ -20,6 +22,7 @@ platformdirs==4.1.0
 pluggy==1.3.0
 pre-commit==3.5.0
 pydantic==1.10.13
+pydoclint==0.3.8
 pyproject-hooks==1.0.0
 pytest==7.4.3
 pytest-cov==4.1.0

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -43,7 +43,7 @@ def commit(
     Create a new commit of all uncommitted changes on the branch in the lakeFS file storage.
 
     Parameters
-    -------
+    ----------
     client: LakeFSClient
         lakeFS client object.
     repository: str
@@ -132,6 +132,11 @@ def delete_branch(
         Name of the branch to be deleted.
     missing_ok: bool
         Ignore errors if the requested branch does not exist in the repository.
+
+    Raises
+    ------
+    NotFoundException
+        If the branch does not exist in the repository and ``missing_ok=False``.
     """
     try:
         client.branches_api.delete_branch(repository=repository, branch=branch)
@@ -150,7 +155,7 @@ def list_branches(client: LakeFSClient, repository: str, prefix: str | None = No
         lakeFS client object.
     repository: str
         Name of the repository for which to list branches.
-    prefix: str
+    prefix: str | None
         Return branches prefixed with this value.
 
     Returns

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -29,7 +29,7 @@ class LakectlConfig(NamedTuple):
 
         Parameters
         ----------
-        path: str
+        path: str | Path
             Path to the YAML configuration file.
 
         Returns
@@ -37,6 +37,10 @@ class LakectlConfig(NamedTuple):
         LakectlConfig
             The immutable loaded configuration. Missing values are filled with ``None`` placeholders.
 
+        Raises
+        ------
+        FileNotFoundError
+            If the configuration file does not exist.
         """
         if not Path(path).exists():
             raise FileNotFoundError(path)

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -39,7 +39,7 @@ def translate_lakefs_error(
 
     Parameters
     ----------
-    error: lakefs_client.ApiException
+    error: ApiException | HTTPError
         The exception returned by the lakeFS API.
     rpath: str | None
         The remote resource path involved in the error.

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -17,8 +17,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, Iterable, Literal, cast
 
+import fsspec.callbacks
 from fsspec import filesystem
-from fsspec.callbacks import _DEFAULT_CALLBACK, Callback
+from fsspec.callbacks import _DEFAULT_CALLBACK
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from fsspec.utils import stringify_path
 from lakefs_sdk import Configuration
@@ -163,7 +164,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         Raises
         ------
-        ApiException
+        OSError
             Translated error from the lakeFS API call, if any.
         """
         try:
@@ -277,7 +278,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         rpath: str | os.PathLike[str],
         lpath: str | os.PathLike[str],
-        callback: Callback = _DEFAULT_CALLBACK,
+        callback: fsspec.callbacks.Callback = _DEFAULT_CALLBACK,
         outfile: Any = None,
         precheck: bool = True,
         **kwargs: Any,
@@ -291,7 +292,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             The remote path to download to local storage. Must be a fully qualified lakeFS URI, and point to a single file.
         lpath: str | os.PathLike[str]
             The local path on disk to save the downloaded file to.
-        callback: Callback
+        callback: fsspec.callbacks.Callback
             An fsspec callback to use during the operation. Can be used to report download progress.
         outfile: Any
             A file-like object to save the downloaded content to. Can be used in place of ``lpath``.
@@ -571,7 +572,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         lpath: str | os.PathLike[str],
         rpath: str | os.PathLike[str],
-        callback: Callback = _DEFAULT_CALLBACK,
+        callback: fsspec.callbacks.Callback = _DEFAULT_CALLBACK,
         presign: bool = False,
         storage_options: dict[str, Any] | None = None,
     ) -> None:
@@ -591,7 +592,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             The local path to upload to the lakeFS block storage.
         rpath: str | os.PathLike[str]
             The remote target path to upload the local file to. Must be a fully qualified lakeFS URI.
-        callback: Callback
+        callback: fsspec.callbacks.Callback
             An fsspec callback to use during the operation. Can be used to report download progress.
         presign: bool
             Whether to use pre-signed URLs to upload the object via HTTP(S) using ``urllib.request``.
@@ -660,7 +661,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         lpath: str | os.PathLike[str],
         rpath: str | os.PathLike[str],
-        callback: Callback = _DEFAULT_CALLBACK,
+        callback: fsspec.callbacks.Callback = _DEFAULT_CALLBACK,
         precheck: bool = True,
         use_blockstore: bool = False,
         presign: bool = False,
@@ -678,7 +679,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             The local path on disk to upload to the lakeFS server.
         rpath: str | os.PathLike[str]
             The remote target path to upload the local file to. Must be a fully qualified lakeFS URI.
-        callback: Callback
+        callback: fsspec.callbacks.Callback
             An fsspec callback to use during the operation. Can be used to report download progress.
         precheck: bool
             Check if ``lpath`` already exists and compare its checksum with that of ``rpath``, skipping the download if they match.

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -601,7 +601,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         Raises
         ------
         ValueError
-            If the blockstore type returned by the lakeFS API is not supported.
+            If the blockstore type returned by the lakeFS API is not supported by fsspec.
         """
         rpath = stringify_path(rpath)
         lpath = stringify_path(lpath)

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -215,7 +215,7 @@ class LakeFSTransaction(Transaction):
         ----------
         repository: str
             Name of the repository.
-        ref: str | Commit
+        ref: str | Placeholder[Commit]
             Commit SHA or commit placeholder object to resolve.
         parent: int
             Optionally parse a parent of ``ref`` instead of ``ref`` itself as indicated by the number.

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -30,9 +30,9 @@ def depaginate(
     ----------
     api: Callable[..., PaginatedApiResponse]
         The lakeFS client API to call. Must return a paginated response with the ``pagination`` and ``results`` fields set.
-    args: Any
+    *args: Any
         Positional arguments to pass to the API call.
-    kwargs: Any
+    **kwargs: Any
         Keyword arguments to pass to the API call.
 
     Yields
@@ -85,8 +85,13 @@ def parse(path: str) -> tuple[str, str, str]:
 
     Returns
     -------
-    str
+    tuple[str, str, str]
         A 3-tuple of repository name, reference, and resource name.
+
+    Raises
+    ------
+    ValueError
+        If the path does not conform to the lakeFS URI format.
     """
 
     # First regex reflects the lakeFS repository naming rules:


### PR DESCRIPTION
This PR adds `pydoclint` as a dev dependency and pre-commit hook.

All non-confirming docstrings in the source code have been updated to pass the check.