### PR TITLE
Overload `LakeFSFile.__del__` to pass statement

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -859,6 +859,10 @@ class LakeFSFile(AbstractBufferedFile):
             repository, branch, resource = parse(path)
             create_branch(self.fs.client, repository, branch, self.fs.source_branch)
 
+    def __del__(self):
+        """Custom deleter, only here to unset the base class behavior."""
+        pass
+
     def _upload_chunk(self, final: bool = False) -> bool:
         """
         Commit the file on final chunk via single-shot upload, no-op otherwise.


### PR DESCRIPTION
Previously, the file was closed again on deletion, which is bad practice if an exception occurred in write mode, since any exception on write will immediately reappear in the exit routine.

This has potential to disturb Python exit cleanup, so we just unset the closing attempt in `__del__`. Any users wanting to upload a file implicitly have to use a context manager (which is preferred, anyway), otherwise, they have to call `file.close()` themselves.

Fixes #218.