### PR TITLE
Remove dunder methods from API docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ plugins:
             show_signature_annotations: true
             signature_crossrefs: true
             merge_init_into_class: false
+            filters: ["!^_{1,2}"]
   - mknotebooks:
       execute: true
       # https://github.com/greenape/mknotebooks/blob/master/examples/cell_tag_remove/mkdocs.yml


### PR DESCRIPTION
Since `LakeFSFile.__del__` was overloaded, it appeared in the docs, as mkdocstrings only removes single-underscore methods from the rendered documentation.

`__init__` methods are excluded with a different flag already, so to fix, just extend the filter regex to double-leading-underscore methods.