### PR TITLE
Run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,24 +10,28 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0
+    rev: v1.7.1
     hooks:
       # See https://github.com/pre-commit/mirrors-mypy/blob/main/.pre-commit-hooks.yaml
      - id: mypy
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.6
     hooks:
     - id: bandit
       args: [-c, pyproject.toml]
       additional_dependencies: ["bandit[toml]"]
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.3.8
+    hooks:
+      - id: pydoclint
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.3.0
     hooks:
@@ -47,7 +51,3 @@ repos:
           - --output-file=requirements-docs.txt
           - pyproject.toml
         files: ^(pyproject\.toml|requirements-docs\.txt)$
-  - repo: https://github.com/jsh9/pydoclint
-    rev: 0.3.8
-    hooks:
-      - id: pydoclint


### PR DESCRIPTION
Bumps `bandit` to v1.7.6, `mypy` to v1.7.1, and `ruff` to v0.1.7.

Also moves the `pydoclint` hook up before the pip compiles, since those take much longer than pydoclint itself.