### PR TITLE
Correctly handle dircache for recursive `ls` calls

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -406,6 +406,58 @@ class LakeFSFileSystem(AbstractFileSystem):
             "type": "directory",
         }
 
+    def _update_dircache(self, info: list) -> None:
+        """Update logic for dircache (optionally recursive) based on lakeFS API response"""
+        parents = {self._parent(i["name"]) for i in info}
+        for pp in parents:
+            # subset of info entries which are direct descendants of `parent`
+            dir_info = [i for i in info if self._parent(i["name"]) == pp]
+
+            if pp not in self.dircache:
+                self.dircache[pp] = dir_info
+                continue
+
+            # Merge existing dircache entry with updated listing, which contains either:
+            # - files not present in the cache yet
+            # - a fresh listing (if `refresh=True`)
+
+            cache_entry = self.dircache[pp][:]
+
+            old_names = {e["name"] for e in cache_entry}
+            new_names = {e["name"] for e in dir_info}
+
+            to_remove = old_names - new_names
+            to_update = old_names.intersection(new_names)
+
+            # Remove all entries no longer present in the current listing
+            cache_entry = [e for e in cache_entry if e["name"] not in to_remove]
+
+            # Overwrite existing entries in the cache with its updated values
+            for name in to_update:
+                old_idx = next(idx for idx, e in enumerate(cache_entry) if e["name"] == name)
+                new_entry = next(e for e in info if e["name"] == name)
+
+                cache_entry[old_idx] = new_entry
+                dir_info.remove(new_entry)
+
+            # Add the remaining (new) entries to the cache
+            cache_entry.extend(dir_info)
+            self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))
+
+    def _ls_from_cache(self, path: str, recursive: bool = False) -> Any | list | None:
+        """Override of ``AbstractFileSystem._ls_from_cache`` with support for recursive listings."""
+        if not recursive:
+            return super()._ls_from_cache(path)
+
+        result = None
+        for key, files in self.dircache.items():
+            if not (key.startswith(path) or path == key + "/"):
+                continue
+            if result is None:
+                result = []
+            result.extend(files)
+        return result
+
     @overload
     def ls(
         self,
@@ -474,6 +526,8 @@ class LakeFSFileSystem(AbstractFileSystem):
         path = cast(str, stringify_path(path))
         repository, ref, prefix = parse(path)
 
+        recursive = kwargs.pop("recursive", False)
+
         # Try lookup in dircache unless explicitly disabled by `refresh=True` kwarg
         use_dircache = True
         if "refresh" in kwargs:
@@ -483,7 +537,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         if use_dircache:
             cache_entry: list[Any] | None = None
             try:
-                cache_entry = self._ls_from_cache(path)
+                cache_entry = self._ls_from_cache(path, recursive=recursive)
             except FileNotFoundError:
                 # we patch files missing from an ls call in the cache entry below,
                 # so this should not be an error.
@@ -493,8 +547,6 @@ class LakeFSFileSystem(AbstractFileSystem):
                 if not detail:
                     return [e["name"] for e in cache_entry]
                 return cache_entry[:]
-
-        recursive = kwargs.pop("recursive", False)
 
         kwargs["prefix"] = prefix
 
@@ -534,35 +586,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         # cache the info if not empty.
         if info:
-            # assumes that the returned info is name-sorted.
-            pp = self._parent(info[0]["name"])
-            info_copy = info[:]
-            if pp in self.dircache:
-                # ls info has files not in cache, so we update them in the cache entry.
-                cache_entry = self.dircache[pp][:]
-
-                old_names = {e["name"] for e in cache_entry}
-                new_names = {e["name"] for e in info_copy}
-
-                to_remove = old_names - new_names
-                to_update = old_names.intersection(new_names)
-
-                # Remove all entries no longer present in the current listing
-                cache_entry = [e for e in cache_entry if e["name"] not in to_remove]
-
-                # Overwrite existing entries in the cache with its updated values
-                for name in to_update:
-                    old_idx = next(idx for idx, e in enumerate(cache_entry) if e["name"] == name)
-                    new_entry = next(e for e in info_copy if e["name"] == name)
-
-                    cache_entry[old_idx] = new_entry
-                    info_copy.remove(new_entry)
-
-                # Add the remaining (new) entries to the cache
-                cache_entry.extend(info_copy)
-                self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))
-            else:
-                self.dircache[pp] = info[:]
+            self._update_dircache(info[:])
 
         if not detail:
             info = [o["name"] for o in info]

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -597,9 +597,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                     }
                 )
 
-        # cache the info if not empty.
         if info:
-            # If recursive, the API doesn't return info items for directories, so they need to be added
             self._update_dircache(info[:])
 
         if not detail:

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -167,7 +167,7 @@ def test_ls_dircache_recursive(
 
     # Dircache invariant: all files in an entry must be direct descendants of its parent
     for cache_dir, files in fs.dircache.items():
-        assert all([fs._parent(v["name"]) == cache_dir for v in files])
+        assert all([fs._parent(v["name"].rstrip("/")) == cache_dir for v in files])
 
     # (2) Dircache correctness, recursive
     cached_listing_recursive = fs.ls(prefix + "/", recursive=True)
@@ -177,7 +177,8 @@ def test_ls_dircache_recursive(
     # (3) Dircache correctness, non-recursive
     cached_listing_nonrecursive = fs.ls(prefix + "/", recursive=False)
     # Non-recursive listing from cache most only contain direct descendants of the listed directory
-    assert all([fs._parent(o["name"]) == prefix for o in cached_listing_nonrecursive])
+    # (and the subfolders directly contained therein)
+    assert all([fs._parent(o["name"].rstrip("/")) == prefix for o in cached_listing_nonrecursive])
 
     # (4) Adding a file should only modify a single dircache entry
     directory = "data"
@@ -197,4 +198,4 @@ def test_ls_dircache_recursive(
 
     # Dircache invariant is maintained
     for cache_dir, files in fs.dircache.items():
-        assert all([fs._parent(v["name"]) == cache_dir for v in files])
+        assert all([fs._parent(v["name"].rstrip("/")) == cache_dir for v in files])

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -124,19 +124,17 @@ def test_ls_dircache_remove_uncached(
     prefix = f"{repository}/{temp_branch}"
     resource = f"{prefix}/"
 
-    try:
-        listing_pre = fs.ls(resource)
-        fs.rm(listing_pre[0]["name"])
+    listing_pre = fs.ls(resource)
+    fs.rm(listing_pre[0]["name"])
 
-        # List again, bypassing the cache...
-        listing_post = fs.ls(resource, refresh=True)
-        assert len(listing_post) == len(listing_pre) - 1
+    # List again, bypassing the cache...
+    listing_post = fs.ls(resource, refresh=True)
+    assert len(listing_post) == len(listing_pre) - 1
 
-        # ... and through the cache (which should have been updated above)
-        listing_post = fs.ls(resource)
-        assert len(listing_post) == len(listing_pre) - 1
-    finally:
-        client_helpers.reset_branch(fs.client, repository, temp_branch)
+    # ... and through the cache (which should have been updated above)
+    listing_post = fs.ls(resource)
+    assert len(listing_post) == len(listing_pre) - 1
+    client_helpers.reset_branch(fs.client, repository, temp_branch)
 
 
 def test_ls_dircache_remove_cached(
@@ -147,12 +145,56 @@ def test_ls_dircache_remove_cached(
     prefix = f"{repository}/{temp_branch}"
     resource = f"{prefix}/"
 
-    try:
-        listing_pre = fs.ls(resource)
-        fs.rm(listing_pre[0]["name"])
+    listing_pre = fs.ls(resource)
+    fs.rm(listing_pre[0]["name"])
 
-        # List again, cache should have been invalidated by rm
-        listing_post = fs.ls(resource)
-        assert len(listing_post) == len(listing_pre) - 1
-    finally:
-        client_helpers.reset_branch(fs.client, repository, temp_branch)
+    # List again, cache should have been invalidated by rm
+    listing_post = fs.ls(resource)
+    assert len(listing_post) == len(listing_pre) - 1
+
+
+def test_ls_dircache_recursive(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    prefix = f"{repository}/{temp_branch}"
+
+    # (1) Basic recursive dircache filling
+    fs.dircache.clear()
+    listing = fs.ls(prefix + "/", recursive=True)
+    assert len(fs.dircache) > 1  # Should contain entries for all sub-folders
+
+    # Dircache invariant: all files in an entry must be direct descendants of its parent
+    for cache_dir, files in fs.dircache.items():
+        assert all([fs._parent(v["name"]) == cache_dir for v in files])
+
+    # (2) Dircache correctness, recursive
+    cached_listing_recursive = fs.ls(prefix + "/", recursive=True)
+    # Recursive listing from cache must contain all items, ordering need not be preserved
+    assert {o["name"] for o in cached_listing_recursive} == {o["name"] for o in listing}
+
+    # (3) Dircache correctness, non-recursive
+    cached_listing_nonrecursive = fs.ls(prefix + "/", recursive=False)
+    # Non-recursive listing from cache most only contain direct descendants of the listed directory
+    assert all([fs._parent(o["name"]) == prefix for o in cached_listing_nonrecursive])
+
+    # (4) Adding a file should only modify a single dircache entry
+    directory = "data"
+    filename = "new-file.txt"
+    rpath = f"{prefix}/{directory}/{filename}"
+
+    old_cache_len = len(fs.dircache.get(f"{prefix}/{directory}"))
+
+    fs.pipe(rpath, b"data")
+    _ = fs.ls(prefix + "/", refresh=True, recursive=True)
+
+    cache_entry = fs.dircache.get(f"{prefix}/{directory}")
+
+    # Added file appears in the cache entry for its parent dir
+    assert len(cache_entry) == old_cache_len + 1
+    assert rpath in {f["name"] for f in cache_entry}
+
+    # Dircache invariant is maintained
+    for cache_dir, files in fs.dircache.items():
+        assert all([fs._parent(v["name"]) == cache_dir for v in files])

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -204,7 +204,7 @@ def test_ls_directories(
     repository: str,
     temp_branch: str,
 ) -> None:
-    """Validate that recursive and non-recusive ``ls`` handle directory entries identically."""
+    """Validate that recursive and non-recursive ``ls`` handle directory entries identically."""
     prefix = f"lakefs://{repository}/{temp_branch}"
 
     fs.rm(f"{prefix}/images/", recursive=True)
@@ -218,7 +218,7 @@ def test_ls_directories(
     ls_recursive = fs.ls(prefix + "/", recursive=True)
 
     dirs = [o for o in ls_recursive if o["type"] == "directory"]
-    assert len(dirs) == 2  # does not include root dir itself
+    assert len(dirs) == 2  # includes `dir1/` and `dir1/dir2`, but not the root.
 
     # (2) - non-recursive ls only includes virtual dir entries on the same level
     ls_nonrecursive = fs.ls(prefix + "/", recursive=False)


### PR DESCRIPTION
The previous implementation of `ls` would only update the dircache for a single directory, based on the order of info entries returned from the API.

The new implementation correctly adds all directory entries to the dircache, and makes sure that the responses returned from the cache correctly honor the `recursive` flag.

Closes #200