### PR TITLE
Simplify transaction `Placeholder` class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "appliedAI Initiative", email = "info+oss@appliedai.de" }]
 maintainers = [
-    { name = "Nicholas Junge", email = "n.junge@appliedai.de" },
-    { name = "Max Mynter", email = "m.mynter@appliedai.de" },
-    { name = "Adrian Rumpold", email = "a.rumpold@appliedai.de" },
+    { name = "Nicholas Junge", email = "n.junge@appliedai-institute.de" },
+    { name = "Max Mynter", email = "m.mynter@appliedai-institute.de" },
+    { name = "Adrian Rumpold", email = "a.rumpold@appliedai-institute.de" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=1.0.0", "pyyaml>=6.0.1"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=1.0.0", "pyyaml>=6.0.1", "wrapt"]
 
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,6 +32,7 @@ six==1.16.0
 typing-extensions==4.8.0
 urllib3==2.0.7
 virtualenv==20.25.0
+wrapt==1.16.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -151,4 +151,5 @@ webcolors==1.13
 webencodings==0.5.1
 websocket-client==1.7.0
 widgetsnbextension==4.0.9
+wrapt==1.16.0
 zipp==3.17.0

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -49,6 +49,16 @@ class Placeholder(Generic[T], wrapt.ObjectProxy):
             )
         return getattr(self.__wrapped__, name)
 
+    def __str__(self):
+        """Override to return the string representation of the wrapped object."""
+        if self.__wrapped__ is None:
+            raise RuntimeError(f"Placeholder of '{type(self).__name__}' is unfilled.")
+        return str(self.__wrapped__)
+
+    def __repr__(self):
+        """Override representation to represent the wrapped object."""
+        return repr(self.__wrapped__)
+
 
 class LakeFSTransaction(Transaction):
     """

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -47,19 +47,19 @@ class Placeholder(wrapt.ObjectProxy, Generic[T]):
             raise RuntimeError(
                 f" '{name}' attribute of object '{type(self).__name__}' is unfilled."
             )
-        return getattr(self.__wrapped__, name)
+        return self.__wrapped__.__getattribute__(name)
 
     def __str__(self):
         """Override to return the string representation of the wrapped object."""
         if self.__wrapped__ is None:
             return "<Placeholder>"
-        return str(self.__wrapped__)
+        return self.__wrapped__.__str__
 
     def __repr__(self):
         """Override representation to represent the wrapped object."""
         if self.__wrapped__ is None:
             return "<Placeholder>"
-        return repr(self.__wrapped__)
+        return self.__wrapped__.__repr__
 
 
 class LakeFSTransaction(Transaction):

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 class Placeholder(Generic[T], wrapt.ObjectProxy):
     """A generic placeholder for a value computed by the lakeFS server in a versioning operation during a transaction."""
 
-    def __init__(self, wrapped: T = None):
+    def __init__(self, wrapped: T | None = None):
         super(Placeholder, self).__init__(wrapped)
 
     @property

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -31,7 +31,6 @@ class Placeholder(Generic[T], wrapt.ObjectProxy):
 
     def __init__(self, wrapped: T | None = None):
         super().__init__(wrapped)
-        self._self_value = wrapped
 
     @property
     def available(self) -> bool:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -24,9 +24,9 @@ def test_transaction_commit(
         sha = tx.commit(repository, temp_branch, message=message)
         # stack contains the file to upload, and the commit op.
         assert len(tx.files) == 2
-        assert not sha.available()
+        assert not sha.available
 
-    assert sha.available()
+    assert sha.available
 
     commits = fs.client.refs_api.log_commits(
         repository=repository,
@@ -35,7 +35,7 @@ def test_transaction_commit(
     latest_commit = commits.results[0]
 
     assert latest_commit.message == message
-    assert latest_commit.id == sha.value.id
+    assert latest_commit.id == sha.id
 
 
 def test_transaction_tag(fs: LakeFSFileSystem, repository: str) -> None:
@@ -45,11 +45,11 @@ def test_transaction_tag(fs: LakeFSFileSystem, repository: str) -> None:
             sha = tx.rev_parse(repository, "main")
             tag = tx.tag(repository=repository, ref=sha, tag="v2")
 
-        assert sha.available()
+        assert sha.available
 
         tags = fs.client.tags_api.list_tags(repository).results
         assert tags[0].id == tag
-        assert tags[0].commit_id == sha.value.id
+        assert tags[0].commit_id == sha.id
     finally:
         fs.client.tags_api.delete_tag(repository=repository, tag=tag)
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from lakefs_sdk.models import Commit
+
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory, with_counter
 
@@ -184,10 +186,9 @@ def test_placeholder_representations(
     with fs.transaction as tx:
         fs.put_file(lpath, rpath)
         sha = tx.commit(repository, temp_branch, message=message)
-        assert str(sha) == "<Placeholder>"
-        assert repr(sha) == "<Placeholder>"
     latest_commit = fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results[
         0
     ]
+    assert isinstance(sha, Commit)
     assert sha.id == latest_commit.id
     assert repr(sha.id) == repr(latest_commit.id)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,9 +1,6 @@
 from typing import Any
 
-from lakefs_sdk.models import Commit
-
 from lakefs_spec import LakeFSFileSystem
-from lakefs_spec.transaction import Placeholder
 from tests.util import RandomFileFactory, with_counter
 
 
@@ -187,19 +184,10 @@ def test_placeholder_representations(
     with fs.transaction as tx:
         fs.put_file(lpath, rpath)
         sha = tx.commit(repository, temp_branch, message=message)
-        assert str(sha) == "<Placeholder for Commit>"
-        assert repr(sha) == repr(Commit)
+        assert str(sha) == "<Placeholder>"
+        assert repr(sha) == "<Placeholder>"
     latest_commit = fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results[
         0
     ]
     assert sha.id == latest_commit.id
     assert repr(sha.id) == repr(latest_commit.id)
-
-
-def test_placeholder_initialization() -> None:
-    unexpected_placeholder: Placeholder = Placeholder()
-    assert unexpected_placeholder._expect is None
-    assert unexpected_placeholder.available is False
-
-    expected_placeholder = Placeholder(expect=Commit)
-    assert expected_placeholder._expect == Commit


### PR DESCRIPTION
## Main Changes

Using `wrapt` to refactor the `Placeholder` class with `wrapt.ObjectProxy` as a transparent proxy. 

Remove the need for `unwrap` via overriding of `__getattr__`.

Delete `unwrap_placeholders` utility function.

Make the `available` method an attribute as it needs no computation input.

## Other Changes
 Update maintainer e-mails to institute addresses.

Closes https://github.com/aai-institute/lakefs-spec/issues/207