### PR TITLE
Correctly set docs version number for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Publish documentation
         uses: ./.github/actions/mike-docs
         with:
-          version: ${{ github.ref_name }}
+          version: ${{ github.event.release.tag_name }}
           alias: latest
           push: true
   publish_pypi:


### PR DESCRIPTION
The `github.ref_name` context property appears to no longer be set when making a release through the UI.
This PR applies a workaround, using the `github.event.release.tag_name` property instead.

See actions/runner#2788 for details.

Issue: #227