### PR TITLE
Several small test improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def lakefs_client(lakefs_options: LakeFSOptions) -> LakeFSClient:
 
 
 @pytest.fixture(scope="session")
-def ensurerepo(lakefs_client: LakeFSClient) -> str:
+def repository(lakefs_client: LakeFSClient) -> str:
     # no loop, assumes there exist fewer than 100 repos.
     reponames = [r.id for r in lakefs_client.repositories_api.list_repositories().results]
 
@@ -85,11 +85,6 @@ def ensurerepo(lakefs_client: LakeFSClient) -> str:
             )
         )
     return _TEST_REPO
-
-
-@pytest.fixture(scope="session")
-def repository(ensurerepo: str) -> str:
-    return ensurerepo
 
 
 @pytest.fixture

--- a/tests/smoke_tests/test_abstractfile.py
+++ b/tests/smoke_tests/test_abstractfile.py
@@ -38,7 +38,7 @@ def test_readline(
         lpath.unlink(missing_ok=True)
 
 
-def test_info(
+def test_fileinfo(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
     rnd_file = random_file_factory.make()

--- a/tests/smoke_tests/test_abstractfilesystem.py
+++ b/tests/smoke_tests/test_abstractfilesystem.py
@@ -1,5 +1,5 @@
 import filecmp
-import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -216,17 +216,17 @@ def test_copy(
 
 
 def test_get_file(
-    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+    tmp_path: Path,
 ) -> None:
-    try:
-        random_file = random_file_factory.make()
-        lpath1 = str(random_file)
-        rpath = f"{repository}/{temp_branch}/{random_file.name}"
-        fs.put(lpath=lpath1, rpath=rpath)
+    random_file = random_file_factory.make()
+    lpath1 = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+    fs.put(lpath=lpath1, rpath=rpath)
 
-        tmp_dir = tempfile.TemporaryDirectory()
-        lpath2 = f"{tmp_dir.name}/{random_file.name}"
-        fs.get(rpath=rpath, lpath=lpath2)
-        assert filecmp.cmp(lpath1, lpath2)
-    finally:
-        tmp_dir.cleanup()
+    lpath2 = str(tmp_path / random_file.name)
+    fs.get(rpath=rpath, lpath=lpath2)
+    assert filecmp.cmp(lpath1, lpath2)


### PR DESCRIPTION
1) Remove `ensurerepo`, and just ensure the repository directly in `repository`.
2) Rename `test_info` to `test_fileinfo` to more directly convey that it is the file's info attribute that is being tested. 
3) Remove the temporary directory from `test_get_file` to prefer the `tmp_path` fixture, which has automatic cleanup.