### PR TITLE
Sdk-follow-up

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -803,7 +803,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             with self.wrapped_api_call(rpath=rpath):
                 super().put_file(lpath, rpath, callback=callback, **kwargs)
 
-    def rm_file(self, path: str | os.PathLike[str]) -> None:
+    def rm_file(self, path: str | os.PathLike[str]) -> None:  # pragma: no cover
         """
         Stage a remote file for removal on a lakeFS server.
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -841,7 +841,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         repository, branch, prefix = parse(path)
 
         with self.wrapped_api_call(rpath=path):
-            lakefs_branch = lakefs.repository(repository).branch(branch)
+            lakefs_branch = lakefs.Repository(repository, client=self.client).branch(branch)
             objs = lakefs_branch.objects(prefix=prefix)
             lakefs_branch.delete_objects([obj.path for obj in objs])
 

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -143,9 +143,9 @@ class LakeFSTransaction(Transaction):
             # fsspec base class calls `append` on the file, which means we
             # have to pop from the left to preserve order.
             f = self.files.popleft()
-            if isinstance(f, AbstractBufferedFile):
+            if isinstance(f, lakefs.object.LakeFSIOBase):
                 if commit:
-                    f.commit()
+                    f.close()
                 else:
                     f.discard()
             else:


### PR DESCRIPTION
Adresses point 1 from #233 

Currently blocked by the fact that the `lakefs` API does not provide a way to discard an opened file. 