### PR TITLE
Fix `fs.rm()` for the recursive case

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -312,6 +312,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         """
         rpath = stringify_path(rpath)
         lpath = stringify_path(lpath)
+
         lp = Path(lpath)
         if precheck and lp.exists() and lp.is_file():
             local_checksum = md5_checksum(lpath, blocksize=self.blocksize)
@@ -670,6 +671,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         """
         lpath = stringify_path(lpath)
         rpath = stringify_path(rpath)
+
         if precheck and Path(lpath).is_file():
             remote_checksum = self.checksum(rpath)
             local_checksum = md5_checksum(lpath, blocksize=self.blocksize)
@@ -722,9 +724,10 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=path):
             branch = lakefs.Branch(repository, ref, client=self.client)
             objgen = branch.objects(prefix=prefix, delimiter="" if recursive else "/")
-            if maxdepth is not None:
+            if maxdepth is None:
                 branch.delete_objects(obj.path for obj in objgen)
             else:
+                # nesting level is just the amount of "/"s in the path, no leading "/".
                 branch.delete_objects(obj.path for obj in objgen if obj.path.count("/") <= maxdepth)
 
             # Directory listing cache for the containing folder must be invalidated

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -721,7 +721,11 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         with self.wrapped_api_call(rpath=path):
             branch = lakefs.Branch(repository, ref, client=self.client)
-            branch.delete_objects([obj.path for obj in branch.objects(prefix=prefix)])
+            objgen = branch.objects(prefix=prefix, delimiter="" if recursive else "/")
+            if maxdepth is not None:
+                branch.delete_objects(obj.path for obj in objgen)
+            else:
+                branch.delete_objects(obj.path for obj in objgen if obj.path.count("/") <= maxdepth)
 
             # Directory listing cache for the containing folder must be invalidated
             self.dircache.pop(self._parent(path), None)

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -48,3 +48,21 @@ def test_rm_recursive(
     assert fs.exists(f"{prefix}/dir1/dir2/c.txt")
     fs.rm(f"{prefix}/dir1", recursive=True)
     assert not fs.exists(f"{prefix}/dir1/dir2/c.txt")
+
+
+def test_rm_recursive_with_maxdepth(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """
+    Check that recursive ``rm`` with maxdepth leaves directories beyond maxdepth untouched.
+    """
+    prefix = f"lakefs://{repository.id}/{temp_branch.id}"
+
+    fs.pipe(f"{prefix}/dir1/b.txt", b"b")
+    fs.pipe(f"{prefix}/dir1/dir2/c.txt", b"c")
+
+    fs.rm(f"{prefix}/dir1", recursive=True, maxdepth=1)
+    # maxdepth is 1-indexed, level 1 being the directory to be removed.
+    assert fs.exists(f"{prefix}/dir1/dir2/c.txt")

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -31,3 +31,20 @@ def test_rm_with_postcommit(
     commits = list(temp_branch.log())
     latest_commit = commits[0]
     assert latest_commit.message == msg
+
+
+def test_rm_recursive(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """Validate that recursive ``rm`` removes subdirectories as well."""
+    prefix = f"lakefs://{repository.id}/{temp_branch.id}"
+
+    fs.pipe(f"{prefix}/dir1/b.txt", b"b")
+    fs.pipe(f"{prefix}/dir1/dir2/c.txt", b"c")
+
+    fs.rm(f"{prefix}/dir1", recursive=False)
+    assert fs.exists(f"{prefix}/dir1/dir2/c.txt")
+    fs.rm(f"{prefix}/dir1", recursive=True)
+    assert not fs.exists(f"{prefix}/dir1/dir2/c.txt")


### PR DESCRIPTION
This happens by a) setting a delimiter in the object listing depending on the value of `recursive` ("/" means directory-local listings), and b) by filtering all results that have a sufficient number of slashes in their file names if `maxdepth` is an integer.

Checks that a subdirectory is not deleted by `fs.rm(..., recursive=False)`.