### PR TITLE
Remove Placeholder from interface typing, use new ReferenceType hint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,4 +128,4 @@ style = 'numpy'
 exclude = '\.git|venv'
 
 [tool.coverage.report]
-exclude_lines = ["pragma: not covered", "@overload"]
+exclude_also = ["@overload"]

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 from lakefs.branch import Branch
-from lakefs.reference import Reference
+from lakefs.reference import Commit, Reference
 from lakefs.repository import Repository
 
 from lakefs_spec import LakeFSFileSystem
+from lakefs_spec.transaction import Placeholder
 from tests.util import RandomFileFactory, put_random_file_on_branch, with_counter
 
 
@@ -170,3 +172,10 @@ def test_placeholder_representations(
     latest_commit = commits[0]
     assert sha.id == latest_commit.id
     assert repr(sha.id) == repr(latest_commit.id)
+
+
+def test_unfilled_placeholder_error() -> None:
+    p: Placeholder[Commit] = Placeholder()
+
+    with pytest.raises(RuntimeError):
+        _ = p.value


### PR DESCRIPTION
As a consequence of my complaints upstream, a new `ReferenceType` was added, which is the union of `str` and everything that marks a reference in lakefs Python code (branches, tags, commits). We now use this everywhere, as it saves space in the interfaces.

Also, since the placeholder is ducktyped to be a ReferenceType always, and passes type checks at runtime (isinstance only), the typing could be relaxed to work with the native reference type only.

Part of #233.