### PR TITLE
Update bug-report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -37,4 +37,4 @@ body:
   - type: input
     attributes:
       label: lakeFS-sdk version
-       placeholder: "Version tag shown in output of `pip show lakefs-sdk`"
+      placeholder: "Version tag shown in output of `pip show lakefs-sdk`"

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -34,7 +34,3 @@ body:
       placeholder: "Version tag shown in output of `pip show lakefs`"
     validations:
       required: true
-  - type: input
-    attributes:
-      label: lakeFS-sdk version
-      placeholder: "Version tag shown in output of `pip show lakefs-sdk`"

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -36,4 +36,5 @@ body:
       required: true
   - type: input
     attributes:
-      label: lakeFS version
+      label: lakeFS-sdk version
+       placeholder: "Version tag shown in output of `pip show lakefs-sdk`"


### PR DESCRIPTION
In the bug template there are lakeFS version requested twice (which results in error as labels are not unique). One 'lakeFS' version request to be replaced with requesting 'lakeFS-sdk' version.