### PR TITLE
Simplify revision parsing in the tutorial notebook

### DIFF
--- a/docs/tutorials/demo_data_science_project.py
+++ b/docs/tutorials/demo_data_science_project.py
@@ -358,13 +358,13 @@ To obtain the actual commit SHA from a branch, we have multiple options.
 Manually, we could go into the lakeFS UI, select the training branch, and navigate to the **Commits** tab.
 There, we take the parent of the previous commit, titled `Add train-test split of 2010 weather data`, and copy its revision SHA (also called `ID`).
 
-In code, we can use a versioning helper called `rev_parse` to obtain commit SHAs for different revisions on the `training` branch.
+In code, we can obtain commit SHAs for different revisions on the `training` branch by using `lakefs.Reference` objects.
 """
 
 # %%
 
-# parent is the parent number of a commit relative to HEAD (the latest commit, for which parent = 0).
-previous_commit = list(repo.branch(TRAINING_BRANCH).log(2))[-1]
+# access the data of the previous commit with a lakefs ref expression, in this case the same as in git.
+previous_commit = repo.ref(f"{TRAINING_BRANCH}~").get_commit()
 fixed_commit_id = previous_commit.id
 print(fixed_commit_id)
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -313,8 +313,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         rpath = stringify_path(rpath)
         lpath = stringify_path(lpath)
 
-        lp = Path(lpath)
-        if precheck and lp.exists() and lp.is_file():
+        if precheck and Path(lpath).is_file():
             local_checksum = md5_checksum(lpath, blocksize=self.blocksize)
             remote_checksum = self.info(rpath).get("checksum")
             if local_checksum == remote_checksum:


### PR DESCRIPTION
From a newly raised issue in lakeFS, it came out that you can actually construct refs from git-like revision selectors, among which is also `$BRANCH~N`, i.e. branch ancestor syntax.

This makes the code much easier and requires only a single API call.