### PR TITLE
Replace `fs._open()` with proper `fs.open()` implementation

### DIFF
--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -59,6 +59,12 @@ def test_lakefs_file_open_write(
     assert new_text == orig_text
 
 
+def test_open_mode_coercion(fs: LakeFSFileSystem, repository: Repository) -> None:
+    """Checks that text mode indicators are stripped."""
+    with fs.open(f"{repository.id}/main/README.md", "rt") as f:
+        assert f.mode == "r"
+
+
 def test_lakefs_file_unknown_mode(fs: LakeFSFileSystem) -> None:
     """Test that a NotImplementedError is raised on unknown mode encounter."""
 

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -63,4 +63,4 @@ def test_lakefs_file_unknown_mode(fs: LakeFSFileSystem) -> None:
     """Test that a NotImplementedError is raised on unknown mode encounter."""
 
     with pytest.raises(NotImplementedError, match="unsupported mode .*"):
-        fs.open("hello.py", mode="ab")
+        fs.open("hello.py", mode="ab")  # type: ignore


### PR DESCRIPTION
This is sensible because a) the builtin `fs.open()` was giving wrong type hints of `AbstractBufferedFile`s, which we no longer use, and b) the new lakeFS APIs allow native handling of non-bytemode open(), which the base `fs.open()` needs a TextIOWrapper for.

No new tests, since all file-system APIs are already being tested. What is missing are integration tests to pandas, polars, etc., since those all rely on `fs.open()`.