### PR TITLE
Update outdated CI actions

### DIFF
--- a/.github/actions/python-deps/action.yaml
+++ b/.github/actions/python-deps/action.yaml
@@ -2,7 +2,7 @@ name: Install Python dependencies
 description: Install all core and optional Python dependencies
 inputs:
   pythonVersion:
-    description: Python version to set up (see actions/setup-python@v4)
+    description: Python version to set up (see actions/setup-python@v5)
     required: true
 runs:
   using: "composite"
@@ -11,7 +11,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.pythonVersion }}
-        cache: 'pip'
+        cache: "pip"
         cache-dependency-path: |
           requirements-dev.txt
           requirements-docs.txt

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -20,31 +20,31 @@ jobs:
       RUFF_CACHE_DIR: "${{ github.workspace }}/.cache/ruff"
       PRE_COMMIT_HOME: "${{ github.workspace }}/.cache/pre-commit"
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # for documentation builds
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-        cache: pip
-        cache-dependency-path: |
-          requirements-dev.txt
-          pyproject.toml
-    - name: Install dependencies
-      run: |
-        pip install -r requirements-dev.txt
-        pip install . --no-deps
-    - name: Cache pre-commit tools
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ env.MYPY_CACHE_DIR }}
-          ${{ env.RUFF_CACHE_DIR }}
-          ${{ env.PRE_COMMIT_HOME }}
-        key: ${{ runner.os }}-${{ hashFiles('requirements-dev.txt', '.pre-commit-config.yaml') }}-linter-cache
-    - name: Run pre-commit checks
-      run: pre-commit run --all-files --verbose --show-diff-on-failure
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for documentation builds
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: |
+            requirements-dev.txt
+            pyproject.toml
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install . --no-deps
+      - name: Cache pre-commit tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.MYPY_CACHE_DIR }}
+            ${{ env.RUFF_CACHE_DIR }}
+            ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ runner.os }}-${{ hashFiles('requirements-dev.txt', '.pre-commit-config.yaml') }}-linter-cache
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files --verbose --show-diff-on-failure
   test:
     name: Test lakefs-spec on ubuntu-latest
     runs-on: ubuntu-latest
@@ -61,22 +61,22 @@ jobs:
           LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "THIS_MUST_BE_CHANGED_IN_PRODUCTION"
           LAKEFS_BLOCKSTORE_TYPE: "local"
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up oldest supported Python (3.9) for testing
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Test on oldest supported Python
-      run: |
-        python -m pip install -r requirements-dev.txt
-        python -m pip install -e .
-        pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up oldest supported Python (3.9) for testing
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Test on oldest supported Python
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+          pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Build documentation for lakefs-spec
     runs-on: ubuntu-latest
@@ -93,24 +93,24 @@ jobs:
           LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "THIS_MUST_BE_CHANGED_IN_PRODUCTION"
           LAKEFS_BLOCKSTORE_TYPE: "local"
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.11 for docs build
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-        cache: pip
-        cache-dependency-path: |
-          requirements-docs.txt
-          pyproject.toml
-    - name: Install dependencies
-      run: |
-        pip install -r requirements-docs.txt
-        pip install . --no-deps
-    - name: Build documentation using mike
-      uses: ./.github/actions/mike-docs
-      with:
-        version: development
-        pre_release: true # include pre-release notification banner
-        push: ${{ github.ref == 'refs/heads/main' }} # build always, publish on 'main' only to prevent version clutter
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.11 for docs build
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: |
+            requirements-docs.txt
+            pyproject.toml
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-docs.txt
+          pip install . --no-deps
+      - name: Build documentation using mike
+        uses: ./.github/actions/mike-docs
+        with:
+          version: development
+          pre_release: true # include pre-release notification banner
+          push: ${{ github.ref == 'refs/heads/main' }} # build always, publish on 'main' only to prevent version clutter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       lakefs: # required for building documentation
-        image: treeverse/lakefs:1.7.0
+        image: treeverse/lakefs:latest
         ports:
           - 8000:8000
         env:
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m build
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -53,7 +53,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
The `upload_artifact`/`download_artifact` actions were using the outdated NodeJS v16 runtime in version v3, which we depended on.

This commit bumps them to the latest version, addressing the [deprecation warnings](https://github.com/aai-institute/lakefs-spec/actions/runs/8092428162) raised by the release workflow.

Also, the lakeFS sidecar container version needed for the docs builds has been made consistent with the PR workflow (which was using the latest Docker image by default).

See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-
node-20/

Note to reviewer: Sorry for the whitespace re-formatting - we should probably adopt common YAML formatting settings going forward ;)