### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         types_or: [python, pyi]
         args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: pydoclint
   - repo: https://github.com/jazzband/pip-tools
-    rev: 7.4.0
+    rev: 7.4.1
     hooks:
       - id: pip-compile
         name: pip-compile requirements-dev.txt

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -118,13 +118,11 @@ class LakeFSFileSystem(AbstractFileSystem):
 
     @classmethod
     @overload
-    def _strip_protocol(cls, path: str | os.PathLike[str] | Path) -> str:
-        ...
+    def _strip_protocol(cls, path: str | os.PathLike[str] | Path) -> str: ...
 
     @classmethod
     @overload
-    def _strip_protocol(cls, path: list[str | os.PathLike[str] | Path]) -> list[str]:
-        ...
+    def _strip_protocol(cls, path: list[str | os.PathLike[str] | Path]) -> list[str]: ...
 
     @classmethod
     def _strip_protocol(cls, path):
@@ -436,8 +434,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         path: str | os.PathLike[str],
         detail: Literal[True] = ...,
         **kwargs: Any,
-    ) -> list[dict[str, Any]]:
-        ...
+    ) -> list[dict[str, Any]]: ...
 
     @overload
     def ls(
@@ -445,8 +442,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         path: str | os.PathLike[str],
         detail: Literal[False],
         **kwargs: Any,
-    ) -> list[str]:
-        ...
+    ) -> list[str]: ...
 
     @overload
     def ls(
@@ -454,8 +450,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         path: str | os.PathLike[str],
         detail: bool = True,
         **kwargs: Any,
-    ) -> list[str] | list[dict[str, Any]]:
-        ...
+    ) -> list[str] | list[dict[str, Any]]: ...
 
     def ls(
         self,

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,6 +1,7 @@
 """
 Useful utilities for handling lakeFS URIs and results of lakeFS API calls.
 """
+
 from __future__ import annotations
 
 import hashlib


### PR DESCRIPTION
This updates ruff to v0.3.1, which brings a few changes to the default code style.