### PR TITLE
Docs: Link to root-level modules in API docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "black",                                     # formatting of signatures in docs
     "mike",
     "appnope",                                   # required only on Darwin, but need to include in lockfile
+    "docstring-parser",
 ]
 
 [tool.setuptools]
@@ -135,7 +136,4 @@ style = 'numpy'
 exclude = '\.git|venv'
 
 [tool.coverage.report]
-exclude_also = [
-    "@overload",
-    "raise NotImplementedError"
-]
+exclude_also = ["@overload", "raise NotImplementedError"]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -26,6 +26,7 @@ comm==0.2.1
 debugpy==1.8.0
 decorator==5.1.1
 defusedxml==0.7.1
+docstring-parser==0.16
 essentials==1.1.5
 essentials-openapi==1.0.9
 executing==2.0.1

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -1,6 +1,7 @@
 """
-Core interface definitions for file system interaction with lakeFS from Python,
-namely the ``LakeFSFileSystem`` and ``LakeFSFile`` classes.
+Core interface definitions for file system interaction with lakeFS from Python.
+
+In particular, the core ``LakeFSFileSystem`` and ``LakeFSFile`` classes.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
This adds functionality to `gen_api_ref_pages.py` to extract the module docstrings for root-level modules in the package, and adds links to them to the index page of the API reference.

![image](https://github.com/aai-institute/lakefs-spec/assets/322624/fad41418-cd38-4a32-a036-87d3b7b544a8)

See also previous PR: #272 