### PR TITLE
Docs: Demonstrate integration of Hugging Face Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Highlights:
 - Simple repository operations in lakeFS
 - Easy access to underlying storage and versioning operations
 - Seamless integration with the fsspec ecosystem
-- Directly access lakeFS objects from popular data science libraries (including Pandas, Polars, DuckDB, PyArrow) with minimal code
+- Directly access lakeFS objects from popular data science libraries (including Pandas, Polars, DuckDB, Hugging Face Datasets, PyArrow) with minimal code
 - Transaction support for reliable data version control
 - Smart data transfers through client-side caching (up-/download)
 - Auto-discovery configuration

--- a/docs/_code/hf_datasets_example.py
+++ b/docs/_code/hf_datasets_example.py
@@ -1,0 +1,12 @@
+from datasets import load_dataset
+
+from lakefs_spec import LakeFSFileSystem
+
+fs = LakeFSFileSystem()
+
+with fs.transaction("quickstart", "main") as tx:
+    lakes = load_dataset("parquet", data_files="lakefs://quickstart/main/lakes.parquet")
+    irish_lakes = lakes.filter(lambda lake: lake["Country"] == "Ireland")
+    irish_lakes.save_to_disk(f"lakefs://quickstart/{tx.branch.id}/irish_lakes")
+
+    tx.commit(message="Add Irish lakes dataset")

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -38,6 +38,18 @@ Similar to the example above, the following code snippet illustrates how to read
 
 1. Makes the lakeFS-spec file system known to DuckDB (`duckdb.register_filesystem(fsspec.filesystem("lakefs"))` can also be used to avoid the direct import of `LakeFSFileSystem`)
 
+## Hugging Face Datasets
+
+[Hugging Face :hugging_face: Datasets](https://huggingface.co/docs/datasets/index){: target="_blank" rel="noopener"} is a library for easily accessing and sharing datasets for Audio, Computer Vision, and Natural Language Processing (NLP) tasks
+It uses [fsspec internally](https://huggingface.co/docs/datasets/filesystems){: target="_blank" rel="noopener"} to retrieve and store datasets located outside the Hugging Face Hub.
+
+Reading a dataset from a lakeFS repository is as simple as passing the `data_files` argument to the `load_dataset` function with a generic dataset script (e.g., `csv` or `parquet` - see the [docs](https://huggingface.co/docs/datasets/en/loading#local-and-remote-files){: target="_blank" rel="noopener"} for a list of available types).
+Datasets can be saved to a lakeFS repository by passing the repository URL to the `save_to_disk()` method of the dataset.
+
+```python hl_lines="8 10"
+--8<-- "docs/_code/hf_datasets_example.py"
+```
+
 ## Polars
 
 !!! warning

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -40,7 +40,7 @@ Similar to the example above, the following code snippet illustrates how to read
 
 ## Hugging Face Datasets
 
-[Hugging Face :hugging_face: Datasets](https://huggingface.co/docs/datasets/index){: target="_blank" rel="noopener"} is a library for easily accessing and sharing datasets for Audio, Computer Vision, and Natural Language Processing (NLP) tasks
+[Hugging Face :hugging_face: Datasets](https://huggingface.co/docs/datasets/index){: target="_blank" rel="noopener"} is a library for easily accessing and sharing datasets for Audio, Computer Vision, and Natural Language Processing (NLP) tasks.
 It uses [fsspec internally](https://huggingface.co/docs/datasets/filesystems){: target="_blank" rel="noopener"} to retrieve and store datasets located outside the Hugging Face Hub.
 
 Reading a dataset from a lakeFS repository is as simple as passing the `data_files` argument to the `load_dataset` function with a generic dataset script (e.g., `csv` or `parquet` - see the [docs](https://huggingface.co/docs/datasets/en/loading#local-and-remote-files){: target="_blank" rel="noopener"} for a list of available types).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Highlights:
 - Simple repository operations in lakeFS
 - Easy access to underlying storage and versioning operations
 - Seamless integration with the fsspec ecosystem
-- Directly access lakeFS objects from popular data science libraries (including Pandas, Polars, DuckDB, PyArrow) with minimal code
+- Directly access lakeFS objects from popular data science libraries (including Pandas, Polars, DuckDB, Hugging Face Datasets, PyArrow) with minimal code
 - Transaction support for reliable data version control
 - Smart data transfers through client-side caching (up-/download)
 - Auto-discovery configuration


### PR DESCRIPTION
Similar to the [lakeFS PR](https://github.com/treeverse/lakeFS/pull/7613), this PR adds an example of how to interact with lakeFS repositories from the HF Datasets library.

It also adds a mention of the library in the repository README and docs landing page.