### PR TITLE
Bump linter dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,20 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       # See https://github.com/pre-commit/mirrors-mypy/blob/main/.pre-commit-hooks.yaml
       - id: mypy
         types_or: [python, pyi]
         args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.1
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7
+    rev: 1.7.8
     hooks:
       - id: bandit
         args: [-c, pyproject.toml]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -15,7 +15,7 @@ async-lru==2.0.4
 attrs==23.2.0
 babel==2.14.0
 beautifulsoup4==4.12.3
-black==24.1.1
+black==24.3.0
 bleach==6.1.0
 certifi==2024.2.2
 cffi==1.16.0


### PR DESCRIPTION
This addresses a Dependabot alert about a vulnerability in black: https://github.com/aai-institute/lakefs-spec/security/dependabot/15

Also bumps pre-commit hooks:

- mypy 1.8.0 -> 1.9.0
- ruff 0.3.1 -> 0.3.5
- bandit 1.7.7 -> 1.7.8