### PR TITLE
Bump minimum fsspec version to 2023.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs>=0.2.0"]
+dependencies = ["fsspec>=2023.12.0", "lakefs>=0.2.0"]
 
 dynamic = ["version"]
 

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -56,11 +56,11 @@ def translate_lakefs_error(
 
     if hasattr(error, "body"):
         # error has a JSON response body attached
-        reason = error.body["message"]
+        reason = error.body.get("message", "")
     else:
         reason = error.reason
 
-    emsg = f"{status} {reason}"
+    emsg = f"{status} {reason}".rstrip()
     if rpath:
         emsg += f": {rpath!r}"
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -69,6 +69,7 @@ class LakeFSFileSystem(AbstractFileSystem):
     """
 
     protocol = "lakefs"
+    transaction_type = LakeFSTransaction
 
     def __init__(
         self,
@@ -134,25 +135,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         if stringify_path(path).endswith("/"):
             return spath + "/"
         return spath
-
-    @property
-    def transaction(self) -> LakeFSTransaction:
-        """
-        A context manager within which file uploads and versioning operations are deferred to a
-        queue, and carried out during when exiting the context.
-
-        Requires the file class to implement ``.commit()`` and ``.discard()`` for the normal and exception cases.
-        """
-        self._transaction: LakeFSTransaction | None
-        if self._transaction is None:
-            self._transaction = LakeFSTransaction(self)
-        return self._transaction
-
-    def start_transaction(self):
-        raise NotImplementedError(
-            "lakeFS transactions should only be used as a context manager via"
-            " `with LakeFSFileSystem.transaction as tx:`"
-        )
 
     @contextmanager
     def wrapped_api_call(

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -45,10 +45,7 @@ class LakeFSTransaction(Transaction):
         The lakeFS file system associated with the transaction.
     """
 
-    def __init__(
-        self,
-        fs: "LakeFSFileSystem",
-    ):
+    def __init__(self, fs: "LakeFSFileSystem"):
         super().__init__(fs=fs)
         self.fs: "LakeFSFileSystem"
         self.files: deque[ObjectWriter] = deque(self.files)

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -53,7 +53,7 @@ def test_implicit_branch_creation(
 
     fs.create_branch_ok = False
     another_non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
-    with pytest.raises(FileNotFoundError, match="Not Found: .*"):
+    with pytest.raises(FileNotFoundError):
         put_random_file_on_branch(random_file_factory, fs, repository, another_non_existing_branch)
 
 


### PR DESCRIPTION
This means that the polymorphic filesystem facility, which was upstreamed to fsspec and first appeared in that release, can go away.

----------------

Contains the error handling fix from #278 as a cherrypick.