### PR TITLE
Support `fs.exists()` on repo root

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: Install Python 3.10 interpreter
@@ -28,8 +26,13 @@ jobs:
       - name: Run pre-commit checks
         run: uvx pre-commit run --all-files --verbose --show-diff-on-failure
   test:
-    name: Test lakefs-spec on ubuntu-latest
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+    name: Run tests on Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     services:
       lakefs:
         image: treeverse/lakefs:latest
@@ -44,12 +47,10 @@ jobs:
           LAKEFS_BLOCKSTORE_TYPE: "local"
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v3
-      - name: Install Python 3.10 interpreter (oldest supported)
-        run: uv python install 3.10
+      - name: Install Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install the project
         run: uv sync --extra dev
       - name: Execute python tests
@@ -58,6 +59,8 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          flags: ${{ matrix.python-version }}
   docs:
     name: Build documentation for lakefs-spec
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To get started with development, you can follow these steps (requires an install
     To spin up a local lakeFS instance quickly for testing, you can use the Docker Compose file bundled with this repository:
 
     ```shell
-    docker-compose -f hack/docker-compose.yml up
+    docker-compose -f hack/compose.yml up
     ```
 
 ## Updating dependencies

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         # Allow slight decreases in coverage for PRs
         threshold: "1%"
+flag_management:
+  default_rules:
+    carryforward: true

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,16 +68,16 @@ Or, if you want to try the latest pre-release version directly from GitHub:
 
 If you don't already have access to a lakeFS server, you can quickly start a local instance using Docker Compose. Before continuing, please make sure Docker is installed and running on your machine.
 
-The lakeFS quickstart deployment can be launched directly with a [configuration file](https://github.com/aai-institute/lakefs-spec/blob/main/hack/docker-compose.yml) provided in the lakeFS-spec repository:
+The lakeFS quickstart deployment can be launched directly with a [configuration file](https://github.com/aai-institute/lakefs-spec/blob/main/hack/compose.yml) provided in the lakeFS-spec repository:
 
 ```shell
-$ curl https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/docker-compose.yml | docker-compose -f - up
+$ curl https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/compose.yml | docker-compose -f - up
 ```
 
-If you do not have `curl` installed on your machine or would like to examine and/or customize the container configuration, you can also create a `docker-compose.yml` file locally and use it with `docker-compose up`:
+If you do not have `curl` installed on your machine or would like to examine and/or customize the container configuration, you can also create a `compose.yml` file locally and use it with `docker-compose up`:
 
-```yaml title="docker-compose.yml"
---8<-- "https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/docker-compose.yml:3:"
+```yaml title="compose.yml"
+--8<-- "https://raw.githubusercontent.com/aai-institute/lakefs-spec/main/hack/compose.yml:3:"
 ```
 
 In order to allow lakeFS-spec to automatically discover credentials to access this lakeFS instance, create a `.lakectl.yaml` in your home directory containing the credentials for the quickstart environment (you can also use `lakectl config` to create this file interactively if you have the `lakectl` tool installed on your machine):

--- a/hack/README.md
+++ b/hack/README.md
@@ -2,7 +2,7 @@
 
 This document contains information on the resources in this directory, and how they can be used in development and testing.
 
-## `docker-compose.yml` - local lakeFS quickstart instance
+## `compose.yml` - local lakeFS quickstart instance
 
 This Docker Compose file bootstraps a local [lakeFS quickstart instance](https://docs.lakefs.io/quickstart/launch.html).
 It does not come with an associated volume, so you can spin it up and down without creating dangling resources.
@@ -13,7 +13,7 @@ Requirements:
 To bootstrap, run the following command:
 
 ```shell
-docker compose -f hack/docker-compose.yml up
+docker compose -f hack/compose.yml up
 ```
 
 To stop the container again, exit with `Ctrl-c`.

--- a/hack/compose.yml
+++ b/hack/compose.yml
@@ -2,6 +2,7 @@
 
 services:
   lakefs:
+    image: treeverse/lakefs:1.37.0
     ports:
       - 8000:8000
     environment:

--- a/hack/compose.yml
+++ b/hack/compose.yml
@@ -1,10 +1,7 @@
 # This docker-compose file provides an ephemeral lakeFS quickstart instance for local development.
 
-version: "3"
-
 services:
   lakefs:
-    image: treeverse/lakefs:1.7.0
     ports:
       - 8000:8000
     environment:

--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -1,7 +1,4 @@
 # This docker-compose file provides an ephemeral lakeFS quickstart instance for local development.
-
-version: "3"
-
 services:
   seaweedfs:
     container_name: sandbox-s3

--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -10,7 +10,7 @@ services:
       - ./config/s3.json:/etc/seaweedfs/s3.json
 
   lakefs:
-    image: treeverse/lakefs:1.7.0
+    image: treeverse/lakefs:1.37.0
     network_mode: host
     depends_on:
       - seaweedfs

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -38,3 +38,23 @@ def test_exists_on_staged_file(
     # upload, verify existence.
     fs.put(lpath, rpath)
     assert fs.exists(rpath)
+
+
+def test_exists_repo_root(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+) -> None:
+    """Test `fs.exists` on the repository root."""
+
+    # Existing repo and branch should return true
+    assert fs.exists(f"lakefs://{repository.id}/main/")
+
+    # Existing repo and commit should return true
+    head_ref = lakefs.Branch(repository.id, "main", client=fs.client).head
+    assert fs.exists(f"lakefs://{repository.id}/{head_ref.id}/")
+
+    # Nonexistent branch should return false
+    assert not fs.exists(f"lakefs://{repository.id}/nonexistent/")
+
+    # Nonexistent repo should return false
+    assert not fs.exists("lakefs://nonexistent/main/")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lakefs_spec.util import _batched
+
+
+def test_batched_empty_iterable():
+    result = list(_batched([], 3))
+    assert result == []
+
+
+def test_batched_single_batch():
+    result = list(_batched([1, 2, 3], 3))
+    assert result == [(1, 2, 3)]
+
+
+def test_batched_multiple_batches():
+    result = list(_batched([1, 2, 3, 4, 5, 6, 7], 3))
+    assert result == [(1, 2, 3), (4, 5, 6), (7,)]
+
+
+def test_batched_batch_size_greater_than_iterable():
+    result = list(_batched([1, 2], 5))
+    assert result == [(1, 2)]
+
+
+def test_batched_invalid_batch_size():
+    with pytest.raises(ValueError, match="n must be at least one"):
+        list(_batched([1, 2, 3], 0))


### PR DESCRIPTION
This PR implements `fs.exists()` on the root of a repository.

Semantically, checking the existence of a repo root equals checking if the specified ref (commit ID/branch name) exists in the repository.

Additionally, it fixes an inconsistency between the `batched` utility function between Python <3.12 and later versions and expands test coverage in CI to all supported Python versions.

Fixes issue #291 