### PR TITLE
Handle partial name matches in `ls` method

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -521,12 +521,14 @@ class LakeFSFileSystem(AbstractFileSystem):
                         }
                     )
                 elif isinstance(obj, ObjectInfo):
-                    # Skip over prefix-only matches, e.g.:
-                    # - foo/bar
-                    # -
-                    # - foo/bar_test.txt
-
-                    # `ls("foo/bar")` should not include `bar_test.txt`
+                    # Skip over prefix-only matches, e.g., given:
+                    #
+                    # foo/
+                    # ├── bar/
+                    # │   └── ...
+                    # └── bar__baz.txt
+                    #
+                    # `ls("foo/bar")` should not include `bar__baz.txt`
                     if not (prefix == "" or prefix.endswith("/")) and obj.path != prefix:
                         continue
 

--- a/tests/regression/test_gh_297.py
+++ b/tests/regression/test_gh_297.py
@@ -1,0 +1,48 @@
+import os
+
+from lakefs import Branch, Repository
+
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_gh_297(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """
+    Regression test for GitHub issue 297: Strange behavior with files containing `__`
+
+    https://github.com/aai-institute/lakefs-spec/issues/297
+    """
+
+    root_dir = "data/foo"
+    files = [
+        f"{root_dir}/bar/axe.just",
+        f"{root_dir}/bar/quux/widg.txt",
+        f"{root_dir}/bar_baz.txt",
+    ]
+    prefix = f"lakefs://{repository.id}/{temp_branch.id}"
+
+    for file in files:
+        fs.pipe(f"{prefix}/{file}", b"data")
+
+    # -- fs.find() should list all files
+    # In #297, the `__` in the filename caused the `find` method to return
+    # just the `foo/bar/` directory and the `foo/bar__baz.txt` file.
+    found_files = fs.find(f"{prefix}/{root_dir}")
+    assert set(found_files) == {f"{repository.id}/{temp_branch.id}/{f}" for f in files}
+
+    # -- fs.walk() should list all files exactly once
+    result = list(fs.walk(f"{prefix}/{root_dir}"))
+    found_files = set()
+    for entry in result:
+        rootdir = entry[0]
+        for filename in entry[2]:
+            found_files.add(os.path.join(rootdir, filename))
+
+    assert found_files == {f"{repository.id}/{temp_branch.id}/{f}" for f in files}
+
+    # Check that the files are present
+    for file in files:
+        assert fs.isfile(f"{prefix}/{file}")

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -142,19 +142,13 @@ def test_ls_no_detail(fs: LakeFSFileSystem, repository: Repository) -> None:
     expected = [f"{resource}/lakes.source.md"]
     # first, verify the API fetch does the expected...
     assert fs.ls(resource, detail=False) == expected
-    assert list(fs.dircache.keys()) == [resource]
+    assert set(fs.dircache.keys()) == {resource}
 
     # ...as well as the cache fetch.
     assert fs.ls(resource, detail=False) == expected
 
     # One API call for the directory object, and one for listing its contents
     assert counter.count("objects_api.list_objects") == 2
-
-    # test the same thing with a subfolder + file prefix
-    resource = f"{prefix}/images/duckdb"
-    fs.ls(resource, detail=False)
-
-    assert set(fs.dircache.keys()) == {f"{prefix}/data", f"{prefix}/images"}
 
 
 def test_ls_dircache_remove_uncached(


### PR DESCRIPTION
This PR fixes the `ls` implementation to exclude partial (prefix-only) matches when listing objects in a repository.

The previous behavior would incorrectly include files with names that are a prefix of the path passed to `ls`, e.g., a file named `foo/bar_1` would be included when listing `foo/bar` (a directory).

The root cause is that the `GET /repositories/{repository}/refs/{ref}/objects/ls` lakeFS API call returns objects based on their prefix, not full name matches, so we have to perform additional filtering in our `ls` method.

A regression test has been added based on the issue description.

Issue: #297