### PR TITLE
Support a wider range of ref expressions

### DIFF
--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -121,7 +121,7 @@ def parse(path: str) -> tuple[str, str, str]:
     uri_parts = {
         "protocol": r"^(?:lakefs://)?",  # leading lakefs:// protocol (optional)
         "repository": r"(?P<repository>[a-z0-9][a-z0-9\-]{2,62})/",
-        "ref expression": r"(?P<ref>\w[\w\-]*)/",
+        "ref expression": r"(?P<ref>\w[\w\-.^~]*)/",
         "resource": r"(?P<resource>.*)",
     }
 

--- a/tests/regression/test_gh_299.py
+++ b/tests/regression/test_gh_299.py
@@ -1,0 +1,36 @@
+from lakefs import Branch, Repository
+
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_gh_299(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """
+    Regression test for GitHub issue 299: Extending ref expression validity.
+    https://github.com/aai-institute/lakefs-spec/issues/299
+    """
+
+    prefix = f"lakefs://{repository.id}/{temp_branch.id}"
+    datapath = f"{prefix}/data.txt"
+
+    # add new file, and immediately commit.
+    fs.pipe(datapath, b"data1")
+    temp_branch.commit(message="Add data.txt")
+
+    # update the file with new data, commit again.
+    fs.pipe(datapath, b"data2")
+    temp_branch.commit(message="Update data.txt")
+
+    assert fs.exists(datapath)
+    assert fs.read_text(datapath) == "data2"
+
+    # caret at the end of the ref should point to the first descendant...
+    previous_datapath = prefix + "^/data.txt"
+    assert fs.read_text(previous_datapath) == "data1"
+
+    # ...and, since we have a linear history, equal "~".
+    previous_with_tilde = previous_datapath.replace("^", "~")
+    assert fs.read_text(previous_with_tilde) == "data1"

--- a/tests/test_spec_utils.py
+++ b/tests/test_spec_utils.py
@@ -18,6 +18,12 @@ from lakefs_spec.spec import parse
         ("my-repo/a/resource.txt", "my-repo", "a", "resource.txt"),
         # case 5: well-formed path with leading lakefs:// scheme
         ("lakefs://my-repo/my-ref/resource.txt", "my-repo", "my-ref", "resource.txt"),
+        # case 6: ref is a tag with a dot, like e.g. in semver.
+        ("lakefs://my-repo/v2.0/resource.txt", "my-repo", "v2.0", "resource.txt"),
+        # case 7: ref is a relative ancestor to an existing branch, like e.g. HEAD~ in git.
+        ("lakefs://my-repo/main~/resource.txt", "my-repo", "main~", "resource.txt"),
+        # case 8: same as case 7, but with first-parent ancestors only.
+        ("lakefs://my-repo/main^^/resource.txt", "my-repo", "main^^", "resource.txt"),
     ],
 )
 def test_path_parsing_success(path: str, repo: str, ref: str, resource: str) -> None:


### PR DESCRIPTION
Adds dot ("."), caret ("^"), and tilde ("~") to the ref identifier regex portion, since they are allowed in ref expressions in lakeFS.

New test cases for each of these scenarios were added to the existing parsing test.


------------

~Also contains a round of `pre-commit autoupdate` that I checked in by mistake apparently.~

Ancestor statements were ~not yet~ verified to work on e.g. a lakeFS quickstart sidecar container, I plan to do that early tomorrow. (But allowing them probably won't hurt, simply because lakeFS mentions them as part of their ref spec.)