### PR TITLE
Run `uv sync --frozen` to not update the lock file in CI

### DIFF
--- a/.github/actions/python-deps/action.yaml
+++ b/.github/actions/python-deps/action.yaml
@@ -13,5 +13,5 @@ runs:
       run: uv python install ${{ inputs.pythonVersion }}
       shell: bash
     - name: Install the project
-      run: uv sync --all-extras --dev
+      run: uv sync --frozen --all-extras --dev
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           pythonVersion: 3.11
       - name: Build and check
-        run: uv run -m build
+        run: uv run --no-sync -m build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Otherwise, setuptools_scm gets confused and creates a dev version even on a published tag.