### PR TITLE
Remove TestPyPI upload due to attestation failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,10 +56,5 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true # tolerate release package file duplicates
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
A generated attestation in the upload job can only be used for a single upload, and is not cleared between uploads - hence, the PyPI release workflow reuses the attestation of TestPyPI, and gets rejected.

For now, remove the TestPyPI upload, so that we don't run into the stale attestation problem.