### PR TITLE
Update `setup-uv` action to v5, tweak install and setup

### DIFF
--- a/.github/actions/python-deps/action.yaml
+++ b/.github/actions/python-deps/action.yaml
@@ -8,10 +8,9 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
-    - name: Install Python interpreter
-      run: uv python install ${{ inputs.pythonVersion }}
-      shell: bash
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ inputs.pythonVersion }}
     - name: Install the project
       run: uv sync --frozen --all-groups
       shell: bash

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,14 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
       - name: Set up Python 3.10 and dependencies
         uses: ./.github/actions/python-deps
         with:
           pythonVersion: "3.10"
       - name: Run pre-commit checks
-        run: uvx pre-commit run --all-files --verbose --show-diff-on-failure
+        run: uv run pre-commit run --all-files --verbose --show-diff-on-failure
   test:
     strategy:
       fail-fast: false
@@ -55,9 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-      - name: Install Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: "Install deps: ${{ matrix.deps.lakefs }}, ${{ matrix.deps.fsspec }}"
         run: |
           uv lock -P ${{ matrix.deps.lakefs }}
@@ -91,8 +89,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
       - name: Set up Python 3.11 and dependencies
         uses: ./.github/actions/python-deps
         with:


### PR DESCRIPTION
v5 of `setup-uv` adds caching and a default venv, so things should be a bit faster on repeated runs.

Since `python-version` allows bootstrapping a Python version directly on action setup, we do that instead.