### PR TITLE
Return custom object metadata from `fs.info()` 

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Execute python tests
         run: uv run pytest -s --cov=src --cov=fsspec --cov-branch --cov-report=xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         types_or: [python, pyi]
         args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -31,12 +31,12 @@ repos:
 #      - id: pydoclint
 #        args: [--check-class-attributes=False]
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.6.6
+    rev: 0.6.11
     hooks:
       - id: uv-lock
         name: Lock project dependencies
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.5.1
+    rev: v1.5.2
     hooks:
       - id: zizmor
         args: [--min-severity=medium]

--- a/hack/compose.yml
+++ b/hack/compose.yml
@@ -2,7 +2,7 @@
 
 services:
   lakefs:
-    image: treeverse/lakefs:1.37.0
+    image: treeverse/lakefs:1.53.1
     ports:
       - 8000:8000
     environment:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -352,12 +352,13 @@ class LakeFSFileSystem(AbstractFileSystem):
                 reference = lakefs.Reference(repository, ref, client=self.client)
                 res = reference.object(resource).stat()
                 return {
+                    "type": "file",
                     "checksum": res.checksum,
                     "content-type": res.content_type,
                     "mtime": res.mtime,
                     "name": f"{repository}/{ref}/{res.path}",
                     "size": res.size_bytes,
-                    "type": "file",
+                    "metadata": res.metadata,
                 }
             except NotFoundException:
                 # fall through, retry with `ls` if it's a directory.
@@ -370,9 +371,9 @@ class LakeFSFileSystem(AbstractFileSystem):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
         return {
+            "type": "directory",
             "name": path.rstrip("/"),
             "size": sum(o.get("size") or 0 for o in out),
-            "type": "directory",
         }
 
     def _update_dircache(self, info: list) -> None:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -26,7 +26,7 @@ from lakefs.object import LakeFSIOBase, ObjectReader, ObjectWriter
 
 from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.transaction import LakeFSTransaction
-from lakefs_spec.types import DirectoryInfoData, FileInfoData
+from lakefs_spec.types import ObjectInfoData
 from lakefs_spec.util import batched, md5_checksum, parse
 
 logger = logging.getLogger("lakefs-spec")
@@ -328,7 +328,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=rpath):
             super().get_file(rpath, lpath, callback=callback, outfile=outfile, **kwargs)
 
-    def info(self, path: str | os.PathLike[str], **kwargs: Any) -> DirectoryInfoData | FileInfoData:
+    def info(self, path: str | os.PathLike[str], **kwargs: Any) -> ObjectInfoData:
         """
         Query a remote lakeFS object's metadata.
 
@@ -341,7 +341,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         Returns
         -------
-        DirectoryInfoData | FileInfoData
+        ObjectInfoData
             A dictionary containing metadata on the object, including its full remote path and object type (file or directory).
 
         Raises

--- a/src/lakefs_spec/types.py
+++ b/src/lakefs_spec/types.py
@@ -1,0 +1,22 @@
+# Functional syntax to allow for the attribute name containing a dash
+from typing import Literal, TypedDict
+
+FileInfoData = TypedDict(
+    "FileInfoData",
+    {
+        "type": Literal["file"],
+        "name": str,
+        "size": int | None,
+        "checksum": str,
+        # TODO: the dash was an unfortunate choice, but is kept for backwards compatibility.
+        "content-type": str | None,
+        "mtime": int,
+        "metadata": dict[str, str] | None,
+    },
+)
+
+
+class DirectoryInfoData(TypedDict):
+    type: Literal["directory"]
+    name: str
+    size: int

--- a/src/lakefs_spec/types.py
+++ b/src/lakefs_spec/types.py
@@ -1,22 +1,19 @@
 # Functional syntax to allow for the attribute name containing a dash
 from typing import Literal, TypedDict
 
-FileInfoData = TypedDict(
-    "FileInfoData",
+from typing_extensions import Required
+
+ObjectInfoData = TypedDict(
+    "ObjectInfoData",
     {
-        "type": Literal["file"],
-        "name": str,
+        "type": Required[Literal["file", "directory"]],
+        "name": Required[str],
         "size": int | None,
-        "checksum": str,
+        "checksum": str | None,
         # TODO: the dash was an unfortunate choice, but is kept for backwards compatibility.
         "content-type": str | None,
-        "mtime": int,
+        "mtime": int | None,
         "metadata": dict[str, str] | None,
     },
+    total=False,
 )
-
-
-class DirectoryInfoData(TypedDict):
-    type: Literal["directory"]
-    name: str
-    size: int

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -11,8 +11,8 @@ from collections import namedtuple
 from collections.abc import Callable, Generator, Iterable, Iterator
 from typing import Any, Protocol
 
-from lakefs_sdk import Pagination
 from lakefs_sdk import __version__ as __lakefs_sdk_version__
+from lakefs_sdk.models.pagination import Pagination
 
 lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
 del __lakefs_sdk_version__

--- a/tests/regression/test_gh_319.py
+++ b/tests/regression/test_gh_319.py
@@ -1,0 +1,30 @@
+from lakefs import Branch, Repository
+
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_gh_319(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """
+    Regression test for GitHub issue 319: lakefs_spec does not display custom metadata
+    https://github.com/aai-institute/lakefs-spec/issues/319
+    """
+
+    rpath = f"lakefs://{repository.id}/{temp_branch.id}/test.txt"
+
+    # Create a file with custom metadata
+    fs.pipe(
+        rpath,
+        b"Hello, world!",
+        metadata={"custom_key": "custom_value"},
+    )
+
+    # Read the file and check the custom metadata
+    info = fs.info(rpath)
+
+    metadata = info.get("metadata")
+    assert metadata is not None, "Metadata should not be None"
+    assert metadata.get("custom_key") == "custom_value"

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -32,3 +32,14 @@ def test_checksum_matching(
 
     # we expect to get one `info` call per upload attempt, but only one actual upload.
     assert counter.count("objects_api.stat_object") == len(blocksizes) + 1
+
+
+def test_checksum_directory(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+) -> None:
+    rpath = f"lakefs://{repository.id}/main/data/"
+    assert fs.isdir(rpath)
+    assert fs.checksum(f"lakefs://{repository.id}/data/") is None, (
+        "Checksum of a directory should be None"
+    )

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -40,6 +40,4 @@ def test_checksum_directory(
 ) -> None:
     rpath = f"lakefs://{repository.id}/main/data/"
     assert fs.isdir(rpath)
-    assert fs.checksum(f"lakefs://{repository.id}/data/") is None, (
-        "Checksum of a directory should be None"
-    )
+    assert fs.checksum(rpath) is None, "Checksum of a directory should be None"

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -48,9 +48,14 @@ def test_info_on_commit(
     head = lakefs.Branch(repository.id, "main", client=fs.client).head
 
     binfo = fs.info(f"{prefix}/main/README.md")
+    assert binfo["type"] == "file"
+
     branch_metadata = (binfo["checksum"], binfo["mtime"], binfo["size"])
+
     # fetching directly from commit should yield the same result.
     cinfo = fs.info(f"{prefix}/{head.id}/README.md")
+    assert cinfo["type"] == "file"
+
     commit_metadata = (cinfo["checksum"], cinfo["mtime"], cinfo["size"])
 
     assert branch_metadata == commit_metadata


### PR DESCRIPTION
This PR adds custom object metadata to the result of `fs.info()`.

Additionally, it adds stricter type hints on the return value of `fs.info()` for better type checking and IDE support.

See issue #319.