### PR TITLE
Fix object type inconsistency in `ls`

### DIFF
--- a/src/lakefs_spec/types.py
+++ b/src/lakefs_spec/types.py
@@ -3,10 +3,12 @@ from typing import Literal, TypedDict
 
 from typing_extensions import Required
 
+ObjectType = Literal["file", "directory"]
+
 ObjectInfoData = TypedDict(
     "ObjectInfoData",
     {
-        "type": Required[Literal["file", "directory"]],
+        "type": Required[ObjectType],
         "name": Required[str],
         "size": int | None,
         "checksum": str | None,

--- a/tests/regression/test_gh_321.py
+++ b/tests/regression/test_gh_321.py
@@ -1,0 +1,25 @@
+from lakefs import Branch, Repository
+
+from lakefs_spec.spec import LakeFSFileSystem
+
+
+def test_gh_321(
+    fs: LakeFSFileSystem,
+    repository: Repository,
+    temp_branch: Branch,
+) -> None:
+    """
+    Regression test for GitHub issue 321: ls() method doesn't return the expected type in info
+    https://github.com/aai-institute/lakefs-spec/issues/321
+    """
+
+    from pyarrow.fs import FileSelector, FileType, FSSpecHandler, PyFileSystem
+
+    rpath = f"lakefs://{repository.id}/{temp_branch.id}"
+
+    # Use the fs object to list files in the directory
+    pa_lakefs = PyFileSystem(FSSpecHandler(fs))
+    info = pa_lakefs.get_file_info(FileSelector(f"{rpath}/data", recursive=True))
+
+    for item in info:
+        assert item.type != FileType.Unknown

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -7,6 +7,24 @@ from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory, with_counter
 
 
+def test_ls_basic(fs: LakeFSFileSystem, repository: Repository) -> None:
+    """
+    Check basic ``ls`` behavior and return types.
+    """
+    resource = f"{repository.id}/main/"
+    expected_files = ["README.md", "data", "images", "lakes.source.md"]
+
+    all_results = fs.ls(resource, detail=True)
+    assert len(all_results) == len(expected_files)
+    assert all([o["type"] in ["file", "directory"] for o in all_results])
+    assert all([o["name"].startswith(resource) for o in all_results])
+
+    all_results = fs.ls(resource, detail=False)
+    assert len(all_results) == len(expected_files)
+    assert all([o.startswith(resource) for o in all_results])
+    assert isinstance(all_results, list)
+
+
 @pytest.mark.parametrize("pagesize", [1, 2, 5, 10, 50])
 def test_paginated_ls(fs: LakeFSFileSystem, repository: Repository, pagesize: int) -> None:
     """


### PR DESCRIPTION
The prior implementation of `ls` was returning inconsistent object types compared with `info`, because the `type` for files was set to `object`.

This change ensures that the `type` field in the returned objects is always set to either `file` or `directory`.

Fixes issue #321.