### PR TITLE
fix: ls() object type from "object" to "file"

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -546,7 +546,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                             "mtime": obj.mtime,
                             "name": f"{repository}/{ref}/{obj.path}",
                             "size": obj.size_bytes,
-                            "type": "object",
+                            "type": "file",
                         }
                     )
 


### PR DESCRIPTION
Small fix to return expected value as part of listing.