### PR TITLE
Modify open() to use pre_sign storage configuration as default

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -588,7 +588,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         path: str | os.PathLike[str],
         mode: Literal["r", "rb", "rt", "w", "wb", "wt", "x", "xb", "xt"] = "rb",
-        pre_sign: bool = False,
+        pre_sign: bool | None = None,
         content_type: str | None = None,
         metadata: dict[str, str] | None = None,
         autocommit: bool = True,
@@ -603,8 +603,8 @@ class LakeFSFileSystem(AbstractFileSystem):
             The remote path for which to open a local ``LakeFSFile``. Must be a fully qualified lakeFS URI.
         mode: Literal["r", "rb", "rt", "w", "wb", "wt", "x", "xb", "xt"]
             The file mode indicating its purpose. Use ``r/rb`` for downloads from lakeFS, ``w/wb/x/xb`` for uploads to lakeFS.
-        pre_sign: bool
-            Whether to use a pre-signed URL for the file up-/download.
+        pre_sign: bool | None
+            Whether to use a pre-signed URL for the file up-/download. If ``None``, the value from the storage configuration is used.
         content_type: str | None
             Content type to use for the file, relevant for uploads only.
         metadata: dict[str, str] | None


### PR DESCRIPTION
The current `open()` implementation hardcodes `pre_sign=False` as the default. This PR changes it to `pre_sign=None` to use by default the value inferred from the storage configuration, as done by the underlying `lakefs` library. 