### PR TITLE
feat(fs): Pass kwargs to SDK object wrapper calls

### DIFF
--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -31,7 +31,7 @@ The arguably most important feature of the file system is file transfers.
 
 #### File uploads
 
-To upload a file, you can use the `fs.put()` and `fs.put_file()` methods. 
+To upload a file, you can use the `fs.put()` and `fs.put_file()` methods.
 While `fs.put_file()` operates on single files only, the `fs.put()` API can be used for directory uploads.
 
 ```python
@@ -63,7 +63,7 @@ fs.put("dir", "my-repo/my-ref/dir", recursive=True)
 
     ```python
     fs = LakeFSFileSystem()
-    
+
     fs.put_file("my-repo/my-ref/file.txt", "file.txt", use_blockstore=True)
     ```
 
@@ -114,7 +114,7 @@ my_file_exists = fs.exists("my-repo/my-ref/my-file.txt")
 This function returns `True` if the file exists on that revision, and `False` if it does not. Errors (e.g. permission errors) will be raised, since in that case, object existence cannot be decided.
 
 !!! Warning
-    
+
     `fs.exists()` only works on file objects, and will return `False` if called on directories.
 
 ### Obtaining info on stored objects
@@ -193,3 +193,31 @@ fs.copy("my-repo/branch-a/my-dir/", "my-repo/branch-b/my-dir/", recursive=True)
     Files and directories can only be copied between branches in the same repository, not between different repositories.
 
     Trying to copy to a non-existent branch will not create the branch.
+
+## Controlling file system usage at the API request level
+
+In some cases, it may be necessary to take more control of file operations by customizing API requests.
+Most file operations in lakefs-spec involve communication with the configured lakeFS server, using the lakeFS Python API client to make requests.
+
+You can control API request parameters by passing a `RequestConfig` object to the lakeFS file system upon construction:
+
+```python
+from lakefs_spec import LakeFSFileSystem
+
+class RequestConfig(TypedDict, total=False):
+    """A custom dict type for keyword arguments configuring OpenAPI requests
+    made with the lakeFS SDK."""
+
+    headers: dict[str, Any]
+    content_type: str
+    request_auth: str
+    request_timeout: int | tuple[int, int]
+    preload_content: bool
+    return_http_data_only: bool
+
+
+request_config = {"request_timeout": 2, "content_type": "application/json"}
+fs = LakeFSFileSystem(request_config=request_config)
+```
+
+For example, you can configure the HTTP request headers with the `headers` key, override authentication with the `request_auth` key, and set a timeout for the API request with the `request_timeout` configuration key.

--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -199,7 +199,7 @@ fs.copy("my-repo/branch-a/my-dir/", "my-repo/branch-b/my-dir/", recursive=True)
 In some cases, it may be necessary to take more control of file operations by customizing API requests.
 Most file operations in lakefs-spec involve communication with the configured lakeFS server, using the lakeFS Python API client to make requests.
 
-You can control API request parameters by passing a `RequestConfig` object to the lakeFS file system upon construction. This type is defined in `lakefs_spec.types` and has the following structure:
+You can control API request parameters by passing a [`RequestConfig`](../reference/lakefs_spec/types.md#RequestConfig) object to the lakeFS file system upon construction. This type has the following structure:
 
 ```python
 class RequestConfig(TypedDict, total=False):

--- a/docs/guides/filesystem-usage.md
+++ b/docs/guides/filesystem-usage.md
@@ -199,11 +199,9 @@ fs.copy("my-repo/branch-a/my-dir/", "my-repo/branch-b/my-dir/", recursive=True)
 In some cases, it may be necessary to take more control of file operations by customizing API requests.
 Most file operations in lakefs-spec involve communication with the configured lakeFS server, using the lakeFS Python API client to make requests.
 
-You can control API request parameters by passing a `RequestConfig` object to the lakeFS file system upon construction:
+You can control API request parameters by passing a `RequestConfig` object to the lakeFS file system upon construction. This type is defined in `lakefs_spec.types` and has the following structure:
 
 ```python
-from lakefs_spec import LakeFSFileSystem
-
 class RequestConfig(TypedDict, total=False):
     """A custom dict type for keyword arguments configuring OpenAPI requests
     made with the lakeFS SDK."""
@@ -214,10 +212,17 @@ class RequestConfig(TypedDict, total=False):
     request_timeout: int | tuple[int, int]
     preload_content: bool
     return_http_data_only: bool
-
-
-request_config = {"request_timeout": 2, "content_type": "application/json"}
-fs = LakeFSFileSystem(request_config=request_config)
 ```
 
 For example, you can configure the HTTP request headers with the `headers` key, override authentication with the `request_auth` key, and set a timeout for the API request with the `request_timeout` configuration key.
+
+To use it, simply pass a dictionary with the proper keys and value types to the lakeFS file system:
+
+```python
+from lakefs_spec import LakeFSFileSystem
+from lakefs_spec.types import RequestConfig
+
+
+request_config: RequestConfig = {"request_timeout": 2, "content_type": "application/json"}
+fs = LakeFSFileSystem(request_config=request_config)
+```

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal, TypedDict, cast, overload
+from typing import Any, Literal, cast, overload
 
 import fsspec.callbacks
 import lakefs
@@ -27,24 +27,12 @@ from lakefs.object import LakeFSIOBase, ObjectReader, ObjectWriter
 
 from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.transaction import LakeFSTransaction
-from lakefs_spec.types import ObjectInfoData
+from lakefs_spec.types import ObjectInfoData, RequestConfig
 from lakefs_spec.util import batched, md5_checksum, parse
 
 logger = logging.getLogger("lakefs-spec")
 
 MAX_DELETE_OBJS = 1000
-
-
-class RequestConfig(TypedDict, total=False):
-    """A custom dict type for keyword arguments configuring OpenAPI requests
-    made with the lakeFS SDK."""
-
-    headers: dict[str, Any]
-    content_type: str
-    request_auth: str
-    request_timeout: int | tuple[int, int]
-    preload_content: bool
-    return_http_data_only: bool
 
 
 def prefix_with_underscore(d: RequestConfig) -> dict[str, Any]:

--- a/src/lakefs_spec/types.py
+++ b/src/lakefs_spec/types.py
@@ -1,5 +1,5 @@
 # Functional syntax to allow for the attribute name containing a dash
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 from typing_extensions import Required
 
@@ -19,3 +19,15 @@ ObjectInfoData = TypedDict(
     },
     total=False,
 )
+
+
+class RequestConfig(TypedDict, total=False):
+    """A custom dict type for keyword arguments configuring OpenAPI requests
+    made with the lakeFS SDK."""
+
+    headers: dict[str, Any]
+    content_type: str
+    request_auth: str
+    request_timeout: int | tuple[int, int]
+    preload_content: bool
+    return_http_data_only: bool

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 from pytest import MonkeyPatch
 
 from lakefs_spec import LakeFSFileSystem
+from lakefs_spec.types import RequestConfig
 
 lakefs_version = Version(version("lakefs"))
 
@@ -74,17 +75,20 @@ def test_initialization(monkeypatch: MonkeyPatch, temporary_lakectl_config: str)
 
 
 @pytest.mark.skipif(lakefs_version < Version("0.14"), reason="requires lakefs>=0.14.0")
-def test_request_config(
-    fs: LakeFSFileSystem, repository: Repository, monkeypatch: MonkeyPatch
-) -> None:
+def test_request_config(repository: Repository, monkeypatch: MonkeyPatch) -> None:
     # Mock `get_object` to intercept the API call made on read() below,
     # and assert it contains the custom timeout.
     mock = MagicMock()
     monkeypatch.setattr(objects_api.ObjectsApi, "get_object", mock)
 
     # set a shorter timeout value for the filesystem (= lakeFS client)
-    request_config = {"_request_timeout": 2}
-    fs._request_config = request_config
+    request_config: RequestConfig = {"request_timeout": 2}
+    fs = LakeFSFileSystem(
+        host="localhost:8000",
+        username="AKIAIOSFOLQUICKSTART",
+        password="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        request_config=request_config,
+    )
 
     with fs.open(f"lakefs://{repository.id}/main/lakes.parquet") as fp:
         fp.read(1)


### PR DESCRIPTION
Then, they are supposed to be forwarded to the raw lakeFS client API calls. This makes it possible to pass relevant parameters like timeouts to the actual API calls that are happening under the hood.

---------------------

Works towards #329. The PR on the lakeFS side, which is https://github.com/treeverse/lakeFS/pull/9509, provides kwargs support to many, but I think not all object functionality.

Needs testing against a new `lakefs` Python package release, and better docstrings.