### PR TITLE
docs(demo): Set `exist_ok=True` in demo repository creation

### DIFF
--- a/docs/tutorials/demo_data_science_project.py
+++ b/docs/tutorials/demo_data_science_project.py
@@ -104,7 +104,9 @@ If you have already created one in the UI, make sure to set the `REPO_NAME` vari
 # %%
 import lakefs
 
-repo = lakefs.Repository(REPO_NAME, fs.client).create(storage_namespace=f"local://{REPO_NAME}")
+repo = lakefs.Repository(REPO_NAME, fs.client).create(
+    storage_namespace=f"local://{REPO_NAME}", exist_ok=True
+)
 
 # %% [markdown]
 """


### PR DESCRIPTION
Currently, this prevents local rebuilds of documentation, since the lakeFS server will return a failure on attempting to recreate the repository if it already exists.