### PR TITLE
feat(transaction): Support finer merge customization through kwargs

### DIFF
--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -11,13 +11,16 @@ from typing import TYPE_CHECKING, Literal, TypeVar
 
 import lakefs
 from fsspec.transaction import Transaction
-from lakefs.branch import Branch, Reference
+from lakefs.branch import Branch
 from lakefs.client import Client
 from lakefs.exceptions import ServerException
 from lakefs.object import ObjectWriter
-from lakefs.reference import Commit, ReferenceType
+from lakefs.reference import Commit, Reference, ReferenceType
 from lakefs.repository import Repository
 from lakefs.tag import Tag
+from typing_extensions import Unpack
+
+from lakefs_spec.types import MergeKwargs
 
 T = TypeVar("T")
 
@@ -52,7 +55,7 @@ class LakeFSTransaction(Transaction):
         self.base_branch: Branch | None = None
         self.automerge: bool = False
         self.delete: Literal["onsuccess", "always", "never"] = "onsuccess"
-        self.squash: bool = False
+        self.merge_kwargs: MergeKwargs = {}
         self._ephemeral_branch: Branch | None = None
 
     def __call__(
@@ -62,7 +65,7 @@ class LakeFSTransaction(Transaction):
         branch_name: str | None = None,
         automerge: bool = True,
         delete: Literal["onsuccess", "always", "never"] = "onsuccess",
-        squash: bool = False,
+        merge_kwargs: MergeKwargs | None = None,
     ) -> "LakeFSTransaction":
         """
         Creates an ephemeral branch, conducts all uploads and operations on that branch,
@@ -85,8 +88,8 @@ class LakeFSTransaction(Transaction):
             or failure.
 
             If ``"never"``, the transaction branch is always left in the repository.
-        squash: bool
-            Optionally squash-merges the transaction branch into the base branch.
+        merge_kwargs: MergeKwargs
+            A dictionary containing options to customize the merge of the transaction branch into the base branch.
         """
 
         if isinstance(repository, str):
@@ -106,7 +109,7 @@ class LakeFSTransaction(Transaction):
 
         self.automerge = automerge
         self.delete = delete
-        self.squash = squash
+        self.merge_kwargs = merge_kwargs or {}
 
         ephem_name = branch_name or "transaction-" + "".join(random.choices(string.digits, k=6))  # noqa: S311
         self._ephemeral_branch = Branch(self.repository, ephem_name, client=self.fs.client)
@@ -141,7 +144,7 @@ class LakeFSTransaction(Transaction):
 
         if success and self.automerge:
             if any(self.base_branch.diff(self._ephemeral_branch)):
-                self._ephemeral_branch.merge_into(self.base_branch, squash_merge=self.squash)
+                self._ephemeral_branch.merge_into(self.base_branch, **self.merge_kwargs)
         if self.delete == "always" or (success and self.delete == "onsuccess"):
             self._ephemeral_branch.delete()
 
@@ -175,7 +178,9 @@ class LakeFSTransaction(Transaction):
 
         return self.branch.commit(message, metadata=metadata)
 
-    def merge(self, source_ref: str | Branch, into: str | Branch, squash: bool = False) -> Commit:
+    def merge(
+        self, source_ref: str | Branch, into: str | Branch, **kwargs: Unpack[MergeKwargs]
+    ) -> Commit:
         """
         Merge a branch into another branch in a repository.
 
@@ -189,8 +194,8 @@ class LakeFSTransaction(Transaction):
             Can be a branch name or partial commit SHA.
         into: str | Branch
             Target branch into which the changes will be merged.
-        squash: bool
-            Optionally squash-merges the source reference into the target branch.
+        **kwargs: Unpack[MergeKwargs]
+            Options to control the merge behavior, including squashing and metadata additions.
 
         Returns
         -------
@@ -201,7 +206,7 @@ class LakeFSTransaction(Transaction):
         dest = _ensurebranch(into, self.repository, self.fs.client)
 
         if any(dest.diff(source)):
-            source.merge_into(dest, squash_merge=squash)
+            source.merge_into(dest, **kwargs)
         return dest.head.get_commit()
 
     def revert(self, branch: str | Branch, ref: ReferenceType, parent_number: int = 1) -> Commit:

--- a/src/lakefs_spec/types.py
+++ b/src/lakefs_spec/types.py
@@ -31,3 +31,17 @@ class RequestConfig(TypedDict, total=False):
     request_timeout: int | tuple[int, int]
     preload_content: bool
     return_http_data_only: bool
+
+
+class MergeKwargs(TypedDict, total=False):
+    """Options to control the merge of a transaction branch into the base branch.
+
+    This is essentially the `lakefs_sdk.Merge` model, without the optionals.
+    """
+
+    message: str
+    metadata: dict[str, str]
+    strategy: Literal["dest-wins", "source-wins"]
+    force: bool
+    allow_empty: bool
+    squash_merge: bool


### PR DESCRIPTION
Instead of `squash`, define a `MergeKwargs` type, holding all possible merge keyword argument types supported by the lakeFS API client.

Merge kwargs are given on transaction entry, and are applied in the merge on close if and only if `automerge` is set to true, and no errors occurred in the transaction scope.

--------------

Needs some more documentation, and perhaps a test. This is also technically a breaking change, since users relying on `squash = True` now need to change to `merge_kwargs = {"squash_merge": True}` as described in the original issue.

Fixes #331.