### PR TITLE
docs: correct configuration guide env vars and configfile kwarg

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -39,26 +39,35 @@ from lakefs_spec import LakeFSFileSystem
 fs = LakeFSFileSystem()
 ```
 
-If you cannot use the default location (`$HOME/.lakectl.yaml`), you can read a file from any other location by passing the `configfile` argument:
-
-```python
-from lakefs_spec import LakeFSFileSystem
-
-fs = LakeFSFileSystem(configfile="/path/to/my/configfile.yaml")
-```
-
-## Setting environment variables
-
-It is also possible to specify certain configuration values used for authentication with the lakeFS server with environment variables.
-For these values, the variable name is exactly the constructor argument name prefaced with `LAKEFS_`, e.g. the `host` argument can be set via the `LAKEFS_HOST` environment variable.
+If you cannot use the default location (`$HOME/.lakectl.yaml`), set the `LAKECTL_CONFIG_FILE` environment variable to the desired path before instantiating the file system:
 
 ```python
 import os
 from lakefs_spec import LakeFSFileSystem
 
-os.environ["LAKEFS_HOST"] = "http://my-lakefs.host"
-os.environ["LAKEFS_USERNAME"] = "my-username"
-os.environ["LAKEFS_PASSWORD"] = "my-password"
+os.environ["LAKECTL_CONFIG_FILE"] = "/path/to/my/configfile.yaml"
+
+fs = LakeFSFileSystem()
+```
+
+## Setting environment variables
+
+It is also possible to specify configuration values used for authentication with the lakeFS server with environment variables.
+These follow the same naming scheme as the `lakectl` CLI and override the corresponding values from a `.lakectl.yaml` config file:
+
+| Environment variable | Config file field |
+| --- | --- |
+| `LAKECTL_SERVER_ENDPOINT_URL` | `server.endpoint_url` |
+| `LAKECTL_CREDENTIALS_ACCESS_KEY_ID` | `credentials.access_key_id` |
+| `LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY` | `credentials.secret_access_key` |
+
+```python
+import os
+from lakefs_spec import LakeFSFileSystem
+
+os.environ["LAKECTL_SERVER_ENDPOINT_URL"] = "http://my-lakefs.host"
+os.environ["LAKECTL_CREDENTIALS_ACCESS_KEY_ID"] = "my-access-key-id"
+os.environ["LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY"] = "my-secret-access-key"
 
 # also zero-config.
 fs = LakeFSFileSystem()
@@ -66,7 +75,7 @@ fs = LakeFSFileSystem()
 
 !!! Info
     
-    Not all initialization values can be set via environment variables - the `proxy`, `create_branch_ok`, and `source_branch` arguments can only be supplied in Python.
+    Environment variable discovery is handled by the underlying `lakefs` Python client. The `proxy`, `create_branch_ok`, and `source_branch` arguments of `LakeFSFileSystem` have no environment variable counterpart and can only be supplied in Python.
 
 ## Appendix: Mixing zero-config methods
 
@@ -93,9 +102,9 @@ from lakefs_spec import LakeFSFileSystem
 # first file system, initialized from the config file
 config_fs = LakeFSFileSystem()
 
-os.environ["LAKEFS_HOST"] = "http://my-other-lakefs.host"
-os.environ["LAKEFS_USERNAME"] = "my-username"
-os.environ["LAKEFS_PASSWORD"] = "my-password"
+os.environ["LAKECTL_SERVER_ENDPOINT_URL"] = "http://my-other-lakefs.host"
+os.environ["LAKECTL_CREDENTIALS_ACCESS_KEY_ID"] = "my-access-key-id"
+os.environ["LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY"] = "my-secret-access-key"
 
 envvar_fs = LakeFSFileSystem()
 


### PR DESCRIPTION
## Summary

Fixes #338.

The configuration guide in `docs/guides/configuration.md` advertised two setups that no longer work since the migration to the `lakefs` Python client wrapper:

1. A `configfile="..."` keyword argument on `LakeFSFileSystem`. `LakeFSFileSystem.__init__` does not accept this argument, so passing it ends up in `**storage_options` and silently has no effect on client configuration.
2. `LAKEFS_HOST` / `LAKEFS_USERNAME` / `LAKEFS_PASSWORD` environment variables. The underlying client only auto-discovers the standard `lakectl` variables (`LAKECTL_SERVER_ENDPOINT_URL`, `LAKECTL_CREDENTIALS_ACCESS_KEY_ID`, `LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY`), as confirmed by the tests in `tests/test_fs.py` (e.g. `tests/test_fs.py:54-56`).

## Changes

`docs/guides/configuration.md`:

- Replace the `configfile="..."` example with `LAKECTL_CONFIG_FILE` environment variable usage (the supported way to point at a non-default config file).
- Replace the `LAKEFS_*` environment variables in the "Setting environment variables" section with the actual `LAKECTL_*` ones, including a small reference table mapping each variable to its config-file field.
- Update the "Appendix: Mixing zero-config methods" example to use the correct variable names so the caching demo still reflects reality.
- Reword the info callout about which arguments have no environment variable counterpart.

No code changes; only the configuration guide is touched.

## Test plan

- [ ] `mkdocs build` renders the updated page without warnings
- [ ] Env-var block matches the behaviour covered by `tests/test_fs.py::test_envvar_config` (approximate fixture name)