### PR TITLE
dev: Replace mypy with pyrefly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,13 +9,16 @@ repos:
         exclude: "mkdocs.yml"
       - id: end-of-file-fixer
       - id: mixed-line-ending
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+  - repo: https://github.com/facebook/pyrefly-pre-commit
+    rev: 0.64.0
     hooks:
-      # See https://github.com/pre-commit/mirrors-mypy/blob/main/.pre-commit-hooks.yaml
-      - id: mypy
-        types_or: [python, pyi]
-        args: [--ignore-missing-imports, --scripts-are-modules]
+      - id: pyrefly-check
+        name: Pyrefly (type checking)
+        pass_filenames: false
+        additional_dependencies:
+          - "fsspec>=2024.10.0"
+          - "lakefs>=0.2.0"
+          - "typing_extensions"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,4 @@ exclude-newer = "1 week"
 
 [tool.pyrefly]
 project-excludes = ["docs/**", "tests/**"]
+infer-return-types = "annotated"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,6 @@ exclude_also = ["@overload", "raise NotImplementedError"]
 
 [tool.uv]
 exclude-newer = "1 week"
+
+[tool.pyrefly]
+project-excludes = ["docs/**", "tests/**"]

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -50,7 +50,7 @@ def translate_lakefs_error(
     OSError
         A builtin Python exception ready to be thrown.
     """
-    status = error.status_code
+    status = error.status_code or 0
 
     if hasattr(error, "body"):
         # error has a JSON response body attached

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -146,6 +146,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             return [cls._strip_protocol(p) for p in path]
         spath = super()._strip_protocol(path)
         if stringify_path(path).endswith("/"):
+            # pyrefly: ignore [unsupported-operation]
             return spath + "/"
         return spath
 
@@ -182,6 +183,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         except ServerException as e:
             raise translate_lakefs_error(e, rpath=rpath, message=message, set_cause=set_cause)
 
+    # pyrefly: ignore [bad-override]
     def checksum(self, path: str | os.PathLike[str]) -> str | None:
         """
         Get a remote lakeFS file object's checksum.
@@ -342,6 +344,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=rpath):
             super().get_file(rpath, lpath, callback=callback, outfile=outfile, **kwargs)
 
+    # pyrefly: ignore [bad-override]
     def info(self, path: str | os.PathLike[str], **kwargs: Any) -> ObjectInfoData:
         """
         Query a remote lakeFS object's metadata.
@@ -598,6 +601,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         else:
             return [cast(dict, o) for o in info]
 
+    # pyrefly: ignore [bad-override]
     def open(
         self,
         path: str | os.PathLike[str],
@@ -649,6 +653,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         repo, ref, resource = parse(path)
 
         if mode.startswith("r"):
+            mode = cast(Literal["r", "rb"], mode)
             reference = lakefs.Reference(repo, ref, client=self.client)
             obj = reference.object(resource)
 
@@ -658,6 +663,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                 obj, mode=mode, pre_sign=pre_sign, client=self.client, **self._request_config
             )
         else:
+            mode = cast(Literal["w", "wb", "x", "xb"], mode)
             # for writing ops, ref must be a branch
             branch = lakefs.Branch(repo, ref, client=self.client)
             if self.create_branch_ok:
@@ -675,10 +681,12 @@ class LakeFSFileSystem(AbstractFileSystem):
             )
 
         if self._intrans and not autocommit and "r" not in mode:
+            # pyrefly: ignore [missing-attribute]
             self._transaction.files.append(handler)
 
         return handler
 
+    # pyrefly: ignore [bad-override-param-name]
     def put_file(
         self,
         lpath: str | os.PathLike[str],
@@ -721,6 +729,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=rpath):
             super().put_file(lpath, rpath, callback=callback, **kwargs)
 
+    # pyrefly: ignore [bad-override]
     def rm_file(self, path: str | os.PathLike[str]) -> None:  # pragma: no cover
         """
         Stage a remote file for removal on a lakeFS server.
@@ -825,8 +834,11 @@ class LakeFSFileSystem(AbstractFileSystem):
             The bytes at the end of the requested file.
         """
         f: ObjectReader
+        # pyrefly: ignore [bad-assignment]
         with self.open(path, "rb") as f:
+            # pyrefly: ignore [unsupported-operation]
             f.seek(max(-size, -f._obj.stat().size_bytes), 2)
+            # pyrefly: ignore [bad-return]
             return f.read()
 
     def created(self, path: str | os.PathLike[str]) -> datetime:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("lakefs-spec")
 MAX_DELETE_OBJS = 1000
 
 
-def prefix_with_underscore(d: RequestConfig) -> dict[str, Any]:
+def prefix_with_underscore(d: dict[str, Any]) -> dict[str, Any]:
     return {k if k.startswith("_") else "_" + k: v for k, v in d.items()}
 
 
@@ -78,6 +78,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
     protocol = "lakefs"
     transaction_type = LakeFSTransaction
+    _transaction: LakeFSTransaction | None
 
     def __init__(
         self,
@@ -123,7 +124,9 @@ class LakeFSFileSystem(AbstractFileSystem):
         self.source_branch = source_branch
 
         # a persistent config for all API requests made with the lakefs SDK.
-        self._request_config = prefix_with_underscore(request_config or {})
+        self._request_config: dict[str, Any] = prefix_with_underscore(
+            dict(request_config) if request_config else {}
+        )
 
     @cached_property
     def _lakefs_server_version(self):
@@ -699,10 +702,8 @@ class LakeFSFileSystem(AbstractFileSystem):
                 client=self.client,
                 **self._request_config,
             )
-
-        if self._intrans and not autocommit and "r" not in mode:
-            # pyrefly: ignore [missing-attribute]
-            self._transaction.files.append(handler)
+            if self._intrans and self._transaction is not None and not autocommit:
+                self._transaction.files.append(handler)
 
         return handler
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -15,15 +15,14 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal, cast, overload
 
-import fsspec.callbacks
 import lakefs
-from fsspec.callbacks import _DEFAULT_CALLBACK
+from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from fsspec.spec import AbstractFileSystem
 from fsspec.utils import stringify_path
 from lakefs.client import Client
 from lakefs.exceptions import NotFoundException, ServerException
 from lakefs.models import CommonPrefix, ObjectInfo
-from lakefs.object import LakeFSIOBase, ObjectReader, ObjectWriter
+from lakefs.object import ObjectReader, ObjectWriter
 
 from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.transaction import LakeFSTransaction
@@ -146,7 +145,6 @@ class LakeFSFileSystem(AbstractFileSystem):
             return [cls._strip_protocol(p) for p in path]
         spath = super()._strip_protocol(path)
         if stringify_path(path).endswith("/"):
-            # pyrefly: ignore [unsupported-operation]
             return spath + "/"
         return spath
 
@@ -183,7 +181,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         except ServerException as e:
             raise translate_lakefs_error(e, rpath=rpath, message=message, set_cause=set_cause)
 
-    # pyrefly: ignore [bad-override]
     def checksum(self, path: str | os.PathLike[str]) -> str | None:
         """
         Get a remote lakeFS file object's checksum.
@@ -305,7 +302,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         rpath: str | os.PathLike[str],
         lpath: str | os.PathLike[str],
-        callback: fsspec.callbacks.Callback = _DEFAULT_CALLBACK,
+        callback: Callback = DEFAULT_CALLBACK,
         outfile: Any = None,
         precheck: bool = True,
         **kwargs: Any,
@@ -344,7 +341,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=rpath):
             super().get_file(rpath, lpath, callback=callback, outfile=outfile, **kwargs)
 
-    # pyrefly: ignore [bad-override]
     def info(self, path: str | os.PathLike[str], **kwargs: Any) -> ObjectInfoData:
         """
         Query a remote lakeFS object's metadata.
@@ -601,7 +597,31 @@ class LakeFSFileSystem(AbstractFileSystem):
         else:
             return [cast(dict, o) for o in info]
 
+    @overload
     # pyrefly: ignore [bad-override]
+    def open(
+        self,
+        path: str | os.PathLike[str],
+        mode: Literal["r", "rb"],
+        pre_sign: bool | None = None,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+        autocommit: bool = False,
+        **kwargs: Any,
+    ) -> ObjectReader: ...
+
+    @overload
+    def open(
+        self,
+        path: str | os.PathLike[str],
+        mode: Literal["w", "wb", "x", "xb"],
+        pre_sign: bool | None = None,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+        autocommit: bool = False,
+        **kwargs: Any,
+    ) -> ObjectWriter: ...
+
     def open(
         self,
         path: str | os.PathLike[str],
@@ -611,7 +631,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         metadata: dict[str, str] | None = None,
         autocommit: bool = False,
         **kwargs: Any,
-    ) -> LakeFSIOBase:
+    ) -> ObjectReader | ObjectWriter:
         """
         Dispatch a lakeFS file-like object (local buffer on disk) for the given remote path for up- or downloads depending on ``mode``.
 
@@ -634,7 +654,7 @@ class LakeFSFileSystem(AbstractFileSystem):
 
         Returns
         -------
-        LakeFSIOBase
+        ObjectReader | ObjectWriter
             A local file-like object ready to hold data to be received from / sent to a lakeFS server.
 
         Raises
@@ -691,7 +711,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         self,
         lpath: str | os.PathLike[str],
         rpath: str | os.PathLike[str],
-        callback: fsspec.callbacks.Callback = _DEFAULT_CALLBACK,
+        callback: Callback = DEFAULT_CALLBACK,
         precheck: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -729,7 +749,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.wrapped_api_call(rpath=rpath):
             super().put_file(lpath, rpath, callback=callback, **kwargs)
 
-    # pyrefly: ignore [bad-override]
     def rm_file(self, path: str | os.PathLike[str]) -> None:  # pragma: no cover
         """
         Stage a remote file for removal on a lakeFS server.
@@ -833,13 +852,13 @@ class LakeFSFileSystem(AbstractFileSystem):
         bytes
             The bytes at the end of the requested file.
         """
-        f: ObjectReader
-        # pyrefly: ignore [bad-assignment]
         with self.open(path, "rb") as f:
-            # pyrefly: ignore [unsupported-operation]
-            f.seek(max(-size, -f._obj.stat().size_bytes), 2)
-            # pyrefly: ignore [bad-return]
-            return f.read()
+            nbytes = f._obj.stat().size_bytes
+            if nbytes is None:
+                raise ValueError(f"could not determine size of file {path}")
+
+            f.seek(max(-size, -nbytes), 2)
+            return cast(bytes, f.read())
 
     def created(self, path: str | os.PathLike[str]) -> datetime:
         """

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -854,9 +854,9 @@ class LakeFSFileSystem(AbstractFileSystem):
             The bytes at the end of the requested file.
         """
         with self.open(path, "rb") as f:
-            nbytes = f._obj.stat().size_bytes
-            if nbytes is None:
-                raise ValueError(f"could not determine size of file {path}")
+            # size_bytes is typed int | None, but the None case is impossible
+            # for an existing file - it's optional only client-side (i.e. on uploads).
+            nbytes: int = f._obj.stat().size_bytes  # pyrefly: ignore
 
             f.seek(max(-size, -nbytes), 2)
             return cast(bytes, f.read())

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -7,7 +7,7 @@ import random
 import string
 import warnings
 from collections import deque
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import lakefs
 from fsspec.transaction import Transaction
@@ -46,17 +46,19 @@ class LakeFSTransaction(Transaction):
         The lakeFS file system associated with the transaction.
     """
 
+    # set in __call__
+    repository: str
+    base_branch: Branch
+    _ephemeral_branch: Branch
+
     def __init__(self, fs: "LakeFSFileSystem"):
         super().__init__(fs=fs)
         self.fs: LakeFSFileSystem
         self.files: deque[ObjectWriter] = deque(self.files)
 
-        self.repository: str | None = None
-        self.base_branch: Branch | None = None
         self.automerge: bool = False
         self.delete: Literal["onsuccess", "always", "never"] = "onsuccess"
-        self.merge_kwargs: MergeKwargs = {}
-        self._ephemeral_branch: Branch | None = None
+        self.merge_kwargs: dict[str, Any] = {}
 
     def __call__(
         self,
@@ -109,7 +111,7 @@ class LakeFSTransaction(Transaction):
 
         self.automerge = automerge
         self.delete = delete
-        self.merge_kwargs = merge_kwargs or {}
+        self.merge_kwargs = dict(merge_kwargs) if merge_kwargs else {}
 
         ephem_name = branch_name or "transaction-" + "".join(random.choices(string.digits, k=6))  # noqa: S311
         self._ephemeral_branch = Branch(self.repository, ephem_name, client=self.fs.client)
@@ -117,12 +119,9 @@ class LakeFSTransaction(Transaction):
 
     def __enter__(self):
         logger.debug(
-            # pyrefly: ignore [missing-attribute]
             f"Creating ephemeral branch {self._ephemeral_branch.id!r} "
-            # pyrefly: ignore [missing-attribute]
             f"from branch {self.base_branch.id!r}."
         )
-        # pyrefly: ignore [missing-attribute]
         self._ephemeral_branch.create(self.base_branch, exist_ok=False)
         self.fs._intrans = True
         return self
@@ -139,25 +138,20 @@ class LakeFSTransaction(Transaction):
         self.fs._intrans = False
         self.fs._transaction = None
 
-        # pyrefly: ignore [missing-attribute]
         if any(self._ephemeral_branch.uncommitted()):
-            # pyrefly: ignore [missing-attribute]
             msg = f"Finished transaction on branch {self._ephemeral_branch.id!r} with uncommitted changes."
             if self.delete != "never":
                 msg += " Objects added but not committed are lost."
             warnings.warn(msg)
 
         if success and self.automerge:
-            # pyrefly: ignore [missing-attribute]
             if any(self.base_branch.diff(self._ephemeral_branch)):
-                # pyrefly: ignore [missing-attribute]
                 self._ephemeral_branch.merge_into(self.base_branch, **self.merge_kwargs)
         if self.delete == "always" or (success and self.delete == "onsuccess"):
-            # pyrefly: ignore [missing-attribute]
             self._ephemeral_branch.delete()
 
     @property
-    def branch(self):
+    def branch(self) -> Branch:
         return self._ephemeral_branch
 
     def commit(self, message: str, metadata: dict[str, str] | None = None) -> Reference:
@@ -210,9 +204,7 @@ class LakeFSTransaction(Transaction):
         Commit
             Either the created merge commit, or the head commit of the target branch.
         """
-        # pyrefly: ignore [bad-argument-type]
         source = _ensurebranch(source_ref, self.repository, self.fs.client)
-        # pyrefly: ignore [bad-argument-type]
         dest = _ensurebranch(into, self.repository, self.fs.client)
 
         if any(dest.diff(source)):
@@ -240,7 +232,6 @@ class LakeFSTransaction(Transaction):
             The created revert commit.
         """
 
-        # pyrefly: ignore [bad-argument-type]
         b = _ensurebranch(branch, self.repository, self.fs.client)
 
         ref_id = ref if isinstance(ref, str) else ref.id
@@ -262,8 +253,7 @@ class LakeFSTransaction(Transaction):
             The commit referenced by the expression ``ref``.
         """
 
-        ref_id = ref.id if isinstance(ref, Reference) else ref
-        # pyrefly: ignore [bad-argument-type]
+        ref_id = ref.id if isinstance(ref, Commit | Reference) else ref
         reference = lakefs.Reference(self.repository, ref_id, client=self.fs.client)
         return reference.get_commit()
 
@@ -285,5 +275,4 @@ class LakeFSTransaction(Transaction):
             The requested tag.
         """
 
-        # pyrefly: ignore [bad-argument-type]
         return lakefs.Tag(self.repository, name, client=self.fs.client).create(ref)

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -117,9 +117,12 @@ class LakeFSTransaction(Transaction):
 
     def __enter__(self):
         logger.debug(
+            # pyrefly: ignore [missing-attribute]
             f"Creating ephemeral branch {self._ephemeral_branch.id!r} "
+            # pyrefly: ignore [missing-attribute]
             f"from branch {self.base_branch.id!r}."
         )
+        # pyrefly: ignore [missing-attribute]
         self._ephemeral_branch.create(self.base_branch, exist_ok=False)
         self.fs._intrans = True
         return self
@@ -136,16 +139,21 @@ class LakeFSTransaction(Transaction):
         self.fs._intrans = False
         self.fs._transaction = None
 
+        # pyrefly: ignore [missing-attribute]
         if any(self._ephemeral_branch.uncommitted()):
+            # pyrefly: ignore [missing-attribute]
             msg = f"Finished transaction on branch {self._ephemeral_branch.id!r} with uncommitted changes."
             if self.delete != "never":
                 msg += " Objects added but not committed are lost."
             warnings.warn(msg)
 
         if success and self.automerge:
+            # pyrefly: ignore [missing-attribute]
             if any(self.base_branch.diff(self._ephemeral_branch)):
+                # pyrefly: ignore [missing-attribute]
                 self._ephemeral_branch.merge_into(self.base_branch, **self.merge_kwargs)
         if self.delete == "always" or (success and self.delete == "onsuccess"):
+            # pyrefly: ignore [missing-attribute]
             self._ephemeral_branch.delete()
 
     @property
@@ -170,12 +178,16 @@ class LakeFSTransaction(Transaction):
             The created commit.
         """
 
+        # pyrefly: ignore [missing-attribute]
         diff = list(self.branch.uncommitted())
 
         if not diff:
+            # pyrefly: ignore [missing-attribute]
             logger.warning(f"No changes to commit on branch {self.branch.id!r}.")
+            # pyrefly: ignore [missing-attribute]
             return self.branch.head
 
+        # pyrefly: ignore [missing-attribute]
         return self.branch.commit(message, metadata=metadata)
 
     def merge(
@@ -202,7 +214,9 @@ class LakeFSTransaction(Transaction):
         Commit
             Either the created merge commit, or the head commit of the target branch.
         """
+        # pyrefly: ignore [bad-argument-type]
         source = _ensurebranch(source_ref, self.repository, self.fs.client)
+        # pyrefly: ignore [bad-argument-type]
         dest = _ensurebranch(into, self.repository, self.fs.client)
 
         if any(dest.diff(source)):
@@ -230,6 +244,7 @@ class LakeFSTransaction(Transaction):
             The created revert commit.
         """
 
+        # pyrefly: ignore [bad-argument-type]
         b = _ensurebranch(branch, self.repository, self.fs.client)
 
         ref_id = ref if isinstance(ref, str) else ref.id
@@ -252,6 +267,7 @@ class LakeFSTransaction(Transaction):
         """
 
         ref_id = ref.id if isinstance(ref, Reference) else ref
+        # pyrefly: ignore [bad-argument-type]
         reference = lakefs.Reference(self.repository, ref_id, client=self.fs.client)
         return reference.get_commit()
 
@@ -273,4 +289,5 @@ class LakeFSTransaction(Transaction):
             The requested tag.
         """
 
+        # pyrefly: ignore [bad-argument-type]
         return lakefs.Tag(self.repository, name, client=self.fs.client).create(ref)

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -178,16 +178,12 @@ class LakeFSTransaction(Transaction):
             The created commit.
         """
 
-        # pyrefly: ignore [missing-attribute]
         diff = list(self.branch.uncommitted())
 
         if not diff:
-            # pyrefly: ignore [missing-attribute]
             logger.warning(f"No changes to commit on branch {self.branch.id!r}.")
-            # pyrefly: ignore [missing-attribute]
             return self.branch.head
 
-        # pyrefly: ignore [missing-attribute]
         return self.branch.commit(message, metadata=metadata)
 
     def merge(


### PR DESCRIPTION
Other than the noticeable speedup, this changes the typechecking paradigm in a few places, specifically first-time variable declarations. As a result, we have lots of errors right now, especially in the transaction.

Currently, all errors are suppressed (with pyrefly suppress) to allow migration, though the most pressing issues must be resolved before a potential merge.

-----------

For reviewers:

I blanket-excluded the docs and tests (the docs due to `missing-import` errors), but maybe at least the code part of the docs can be checked.

We have three main classes of errors: 1) wrong overrides in the filesystem, 2) missing attributes in the transaction because it uses the type hints given in `__init__` for type checking, and 3) bad input arguments, usually where we do not `None`-check an optional input. Since we haven't observed any issues in practice, I wonder how we can solve 2) and 3), but the overloads are worth taking a look at imo.