### PR TITLE
dev: Check docs example code with Pyrefly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,7 @@ repos:
       - id: pyrefly-check
         name: Pyrefly (type checking)
         pass_filenames: false
-        additional_dependencies:
-          - "fsspec>=2024.10.0"
-          - "lakefs>=0.2.0"
-          - "typing_extensions"
+        language: system
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/docs/_code/quickstart.py
+++ b/docs/_code/quickstart.py
@@ -17,7 +17,7 @@ with fs.transaction(REPO, BRANCH) as tx:
     tx.commit(message="Add demo data")
 
 # Read back the file contents
-f = fs.open(repo_path, "rt")
+f = fs.open(repo_path, "r")
 print(f.readline())  # prints "Hello, lakeFS!"
 
 # Compare the sizes of local file and repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,5 +151,6 @@ exclude_also = ["@overload", "raise NotImplementedError"]
 exclude-newer = "1 week"
 
 [tool.pyrefly]
-project-excludes = ["docs/**", "tests/**"]
+project-excludes = ["tests/**", "docs/_scripts/**"]
+ignore-missing-imports = ["sklearn.*", "duckdb", "pandas", "pyarrow.*", "polars", "datasets"]
 infer-return-types = "annotated"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,15 @@ Documentation = "https://lakefs-spec.org/latest"
 dev = [
     "build>=0.10.0",
     "pre-commit>=3.3.3",
+    "pyrefly>=0.63.1",
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
+    "pytest-asyncio>=0.24.0",
     "pydoclint",
     # for integration tests.
     "pandas[parquet]",
     "polars",
     "duckdb",
-    "pytest-asyncio>=0.24.0",
 ]
 docs = [
     "mkdocs",
@@ -152,5 +153,5 @@ exclude-newer = "1 week"
 
 [tool.pyrefly]
 project-excludes = ["tests/**", "docs/_scripts/**"]
-ignore-missing-imports = ["sklearn.*", "duckdb", "pandas", "pyarrow.*", "polars", "datasets"]
+ignore-missing-imports = ["datasets", "sklearn.*"]
 infer-return-types = "annotated"

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -856,7 +856,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         with self.open(path, "rb") as f:
             # size_bytes is typed int | None, but the None case is impossible
             # for an existing file - it's optional only client-side (i.e. on uploads).
-            nbytes: int = f._obj.stat().size_bytes  # pyrefly: ignore
+            nbytes: int = f._obj.stat().size_bytes  # pyrefly: ignore[bad-assignment]
 
             f.seek(max(-size, -nbytes), 2)
             return cast(bytes, f.read())

--- a/uv.lock
+++ b/uv.lock
@@ -1415,6 +1415,7 @@ dev = [
     { name = "polars" },
     { name = "pre-commit" },
     { name = "pydoclint" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1457,6 +1458,7 @@ dev = [
     { name = "polars" },
     { name = "pre-commit", specifier = ">=3.3.3" },
     { name = "pydoclint" },
+    { name = "pyrefly", specifier = ">=0.63.1" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -2769,6 +2771,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "0.63.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/66/c3e6c3963fe6bb40b0199745ce6cd5772253ec0a4edfe6db63a646f9d007/pyrefly-0.63.1.tar.gz", hash = "sha256:6819eb0857f5fcaef463ad58778e4121cb8c7c5a974a4739c8aa867e1ef16980", size = 5574619, upload-time = "2026-04-29T05:59:52.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7b/52a34bd3dde4c1b6cf8e8cf8bcbb0fa52b868df2ab07220e130c87877376/pyrefly-0.63.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1bc37f4fe8c3e50f6718bcb1c6cae475e5e24197f6fe8042c3d6ca3d8f2e10da", size = 13102494, upload-time = "2026-04-29T05:59:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e0/2ac0c3e003ba6c855e4775536485c75b18e1aaf5e18e966a033751436416/pyrefly-0.63.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:712733b7c4344644eafa827de88a36e697a1aa282f913da89d3ad26e7dcc2dc2", size = 12597372, upload-time = "2026-04-29T05:59:30.434Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/07/1bb6354ccd7ccca2706fc00cfde952c2e18383a47f0cb5417347df836b7f/pyrefly-0.63.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6cbba7aedc266be0e6a69305e9caa53b3b4bab190bde046ce37a895af5c20a0", size = 36494119, upload-time = "2026-04-29T05:59:33.813Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f5/9c243090872ad3c1f690c782df900468630ad139a0fb309a1185e6838dc7/pyrefly-0.63.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6a99c4acd7ff8418a15f39dd402d8f9bf7d640a8a2536f7a1b34ef7e1b1167c", size = 39262905, upload-time = "2026-04-29T05:59:36.609Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ef/33918f3b5d04e34f8ad7a5d0de493c5d32a93b183b58c7e785571854b608/pyrefly-0.63.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b6490de58b1ec9fe99aa1fbaf0759079a916c0fb75d345439ba2a427aaebc1a", size = 37446668, upload-time = "2026-04-29T05:59:39.549Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d5/f0c9e6938c3f1231405ee77045b2b51c349d1a6aa84ba8717f4829f64bbc/pyrefly-0.63.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d53ec1f8711b24b1e992309b978b219daf2335201f26acafa86f14fbb81804ec", size = 42061281, upload-time = "2026-04-29T05:59:42.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0c/ca7d4f2bc3c17dac9c3da9956d8baa5c4fe4c4e4996ead9b55273b0ee20a/pyrefly-0.63.1-py3-none-win32.whl", hash = "sha256:a9a45d3fc563f02cdca4681e899a775561bd71e923d6ac4a8979d93d7c2aff2a", size = 12086212, upload-time = "2026-04-29T05:59:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b5/1f6373e1fcefca3414baeed4209ecab2f4beb7849a2508517d73e78034ce/pyrefly-0.63.1-py3-none-win_amd64.whl", hash = "sha256:c6470a8eedae0e46d94667fd958cd008f9c2599aa3e6f2f43b6f4e6e87863cc3", size = 12934616, upload-time = "2026-04-29T05:59:48.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ab/116efd46872f88cec697133d0430ce28affcc7247ebdff71429422a3a42b/pyrefly-0.63.1-py3-none-win_arm64.whl", hash = "sha256:b54b068a77341bc50604fb9bd4d0cf37fb74c09fb92344645c596813cc53950a", size = 12434930, upload-time = "2026-04-29T05:59:50.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ignoring the first-party data science imports. This caught a principally disallowed usage of `fs.open()` due to `mode = "rt"`, which we do not support in the open modes literal.